### PR TITLE
[M2] 设置页 + 首次引导

### DIFF
--- a/docs/superpowers/plans/2026-05-02-settings-onboarding.md
+++ b/docs/superpowers/plans/2026-05-02-settings-onboarding.md
@@ -1,0 +1,752 @@
+# 设置页 + 首次引导 实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 实现 `/settings` 表单与首次引导守卫:CoupleProfile 不存在时强制跳转,允许首次创建与后续编辑。
+
+**Architecture:** 新增 `(protected)` 路由组,其 `layout.tsx` (Server Component) 调用 `getCoupleProfile()` 缺失则 `redirect('/settings')`;封面 `/` 迁入该组。设置页用 React 19 `useActionState` + Server Action,zod 校验后 upsert 单例。
+
+**Tech Stack:** Next.js 16 App Router (Server Components & Actions)、React 19、`useActionState`、Prisma、SQLite、zod、animal-island-ui (`Input`、`Button`)、Jest + ts-jest。
+
+**Spec:** `docs/superpowers/specs/2026-05-02-settings-onboarding-design.md`
+
+---
+
+## File Structure
+
+| 文件 | 操作 | 职责 |
+|------|------|------|
+| `src/lib/actions.ts` | 修改 | 新增 `saveCoupleProfileAction` 与 `SettingsFormState` 类型 |
+| `src/lib/__tests__/actions.test.ts` | 修改 | 新增 `describe('saveCoupleProfileAction')` 三个用例 |
+| `src/app/(protected)/layout.tsx` | 创建 | Server Component,profile 缺失则 redirect |
+| `src/app/(protected)/page.tsx` | 创建(由 `src/app/page.tsx` 迁入) | 封面页;移除原内联 redirect |
+| `src/app/page.tsx` | 删除 | 内容已迁入 (protected)/page.tsx |
+| `src/app/settings/page.tsx` | 重写 | Server Component,取 profile 注入表单 |
+| `src/components/SettingsForm.tsx` | 创建 | Client Component,useActionState 表单 |
+
+---
+
+## Task 1: Server Action — 拒绝未来日期(TDD 第一轮)
+
+**Files:**
+- Modify: `src/lib/__tests__/actions.test.ts`(顶部加 mock + 新 describe 块)
+- Modify: `src/lib/actions.ts`(新增 type、ActionSchema、`saveCoupleProfileAction` 骨架)
+
+**目标:** 建立 action 骨架 + 校验失败返回路径,确保未来日期被拒。
+
+- [ ] **Step 1: 在测试文件顶部加 mock 与 dayjs 引入**
+
+修改 `src/lib/__tests__/actions.test.ts` 顶部(在原有 import 之后追加):
+
+```ts
+import dayjs from 'dayjs';
+
+jest.mock('next/cache', () => ({ revalidatePath: jest.fn() }));
+jest.mock('next/navigation', () => ({
+  redirect: (url: string) => {
+    const err = new Error(`NEXT_REDIRECT:${url}`);
+    (err as Error & { digest?: string }).digest = `NEXT_REDIRECT;replace;${url};307;`;
+    throw err;
+  },
+}));
+```
+
+并在文件顶部已有的 import 列表里追加 `saveCoupleProfileAction`:
+
+```ts
+import {
+  // ...其他 import 保持
+  saveCoupleProfileAction,
+} from '../actions';
+```
+
+- [ ] **Step 2: 在文件末尾追加新的 describe 与第一个用例**
+
+```ts
+describe('saveCoupleProfileAction', () => {
+  test('拒绝未来日期', async () => {
+    const fd = new FormData();
+    fd.set('personAName', '小兔子');
+    fd.set('personBName', '大灰狼');
+    fd.set('anniversaryDate', dayjs().add(1, 'day').format('YYYY-MM-DD'));
+    fd.set('siteTitle', '');
+
+    const state = await saveCoupleProfileAction({ ok: true }, fd);
+
+    expect(state.ok).toBe(false);
+    expect(state.fieldErrors?.anniversaryDate).toBe('在一起日期不能晚于今天');
+  });
+});
+```
+
+- [ ] **Step 3: 跑测试确认 FAIL(action 未导出)**
+
+Run: `pnpm test -- --testPathPatterns=actions.test.ts -t "拒绝未来日期"`
+Expected: FAIL,报 "saveCoupleProfileAction is not a function" 或 import 错误。
+
+- [ ] **Step 4: 在 `src/lib/actions.ts` 新增类型与骨架**
+
+在文件顶部 import 区域追加:
+
+```ts
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+import { z } from 'zod';
+```
+
+(注意:原文件已有 `import { CreateDiarySchema, ... } from './schemas';`,zod 自身可能未单独 import,需要新增。)
+
+在文件末尾追加:
+
+```ts
+export type SettingsFormState = {
+  ok: boolean;
+  fieldErrors?: Partial<
+    Record<'personAName' | 'personBName' | 'anniversaryDate' | 'siteTitle', string>
+  >;
+  formError?: string;
+};
+
+const SettingsActionSchema = z.object({
+  personAName: z
+    .string()
+    .trim()
+    .min(1, '请填写第一位的昵称')
+    .max(50, '不超过 50 字'),
+  personBName: z
+    .string()
+    .trim()
+    .min(1, '请填写第二位的昵称')
+    .max(50, '不超过 50 字'),
+  anniversaryDate: z.coerce
+    .date({ error: '请选择日期' })
+    .refine((d) => d.getTime() <= Date.now(), '在一起日期不能晚于今天'),
+  siteTitle: z.string().trim().max(100, '不超过 100 字').optional(),
+});
+
+function zodIssuesToFieldErrors(
+  error: z.ZodError,
+): SettingsFormState['fieldErrors'] {
+  const fieldErrors: SettingsFormState['fieldErrors'] = {};
+  for (const issue of error.issues) {
+    const key = issue.path[0];
+    if (
+      typeof key === 'string' &&
+      ['personAName', 'personBName', 'anniversaryDate', 'siteTitle'].includes(key)
+    ) {
+      const k = key as keyof NonNullable<SettingsFormState['fieldErrors']>;
+      if (!fieldErrors[k]) fieldErrors[k] = issue.message;
+    }
+  }
+  return fieldErrors;
+}
+
+export async function saveCoupleProfileAction(
+  _prev: SettingsFormState,
+  formData: FormData,
+): Promise<SettingsFormState> {
+  const parsed = SettingsActionSchema.safeParse({
+    personAName: formData.get('personAName'),
+    personBName: formData.get('personBName'),
+    anniversaryDate: formData.get('anniversaryDate'),
+    siteTitle: formData.get('siteTitle'),
+  });
+
+  if (!parsed.success) {
+    return { ok: false, fieldErrors: zodIssuesToFieldErrors(parsed.error) };
+  }
+
+  const data = {
+    ...parsed.data,
+    siteTitle: parsed.data.siteTitle?.length ? parsed.data.siteTitle : undefined,
+  };
+
+  try {
+    await updateCoupleProfile(data);
+  } catch {
+    return { ok: false, formError: '保存失败,请稍后重试' };
+  }
+
+  revalidatePath('/');
+  redirect('/');
+}
+```
+
+- [ ] **Step 5: 跑测试确认 PASS**
+
+Run: `pnpm test -- --testPathPatterns=actions.test.ts -t "拒绝未来日期"`
+Expected: PASS,且其他既有用例继续通过。
+
+- [ ] **Step 6: 提交**
+
+```bash
+git add src/lib/actions.ts src/lib/__tests__/actions.test.ts
+git commit -m "feat(actions): saveCoupleProfileAction 骨架 + 拒绝未来日期"
+```
+
+---
+
+## Task 2: 拒绝空白姓名(TDD 第二轮)
+
+**Files:**
+- Modify: `src/lib/__tests__/actions.test.ts`
+
+**目标:** 验证 trim().min(1) 能拦下纯空格姓名。
+
+- [ ] **Step 1: 在 `describe('saveCoupleProfileAction')` 内新增用例**
+
+```ts
+test('拒绝空白姓名(trim 后为空)', async () => {
+  const fd = new FormData();
+  fd.set('personAName', '   ');
+  fd.set('personBName', '大灰狼');
+  fd.set('anniversaryDate', '2024-07-18');
+  fd.set('siteTitle', '');
+
+  const state = await saveCoupleProfileAction({ ok: true }, fd);
+
+  expect(state.ok).toBe(false);
+  expect(state.fieldErrors?.personAName).toBe('请填写第一位的昵称');
+});
+```
+
+- [ ] **Step 2: 跑测试**
+
+Run: `pnpm test -- --testPathPatterns=actions.test.ts -t "拒绝空白姓名"`
+Expected: PASS(Task 1 已实现 trim,直接通过)。
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add src/lib/__tests__/actions.test.ts
+git commit -m "test(actions): 拒绝空白姓名用例"
+```
+
+---
+
+## Task 3: 成功路径(TDD 第三轮)
+
+**Files:**
+- Modify: `src/lib/__tests__/actions.test.ts`
+
+**目标:** 校验通过后写入 DB,并触发 redirect。
+
+- [ ] **Step 1: 在 `describe('saveCoupleProfileAction')` 内新增成功用例**
+
+```ts
+test('成功路径写入 profile 并 redirect 到 /', async () => {
+  const fd = new FormData();
+  fd.set('personAName', '小兔子');
+  fd.set('personBName', '大灰狼');
+  fd.set('anniversaryDate', '2024-07-18');
+  fd.set('siteTitle', '恋爱小岛日记');
+
+  await expect(
+    saveCoupleProfileAction({ ok: true }, fd),
+  ).rejects.toThrow('NEXT_REDIRECT:/');
+
+  const profile = await prisma.coupleProfile.findFirst();
+  expect(profile?.personAName).toBe('小兔子');
+  expect(profile?.personBName).toBe('大灰狼');
+  expect(profile?.siteTitle).toBe('恋爱小岛日记');
+});
+
+test('成功路径下空白 siteTitle 归一化为 null', async () => {
+  const fd = new FormData();
+  fd.set('personAName', '小兔子');
+  fd.set('personBName', '大灰狼');
+  fd.set('anniversaryDate', '2024-07-18');
+  fd.set('siteTitle', '   ');
+
+  await expect(
+    saveCoupleProfileAction({ ok: true }, fd),
+  ).rejects.toThrow('NEXT_REDIRECT:/');
+
+  const profile = await prisma.coupleProfile.findFirst();
+  expect(profile?.siteTitle).toBeNull();
+});
+```
+
+- [ ] **Step 2: 跑全部 saveCoupleProfileAction 用例**
+
+Run: `pnpm test -- --testPathPatterns=actions.test.ts -t "saveCoupleProfileAction"`
+Expected: 4 个用例全部 PASS。
+
+- [ ] **Step 3: 跑全套 jest**
+
+Run: `pnpm test`
+Expected: 既有用例 + 新增用例全部 PASS,无回归。
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add src/lib/__tests__/actions.test.ts
+git commit -m "test(actions): saveCoupleProfileAction 成功路径与 siteTitle 归一化"
+```
+
+---
+
+## Task 4: 路由组与守卫 layout
+
+**Files:**
+- Create: `src/app/(protected)/layout.tsx`
+- Create: `src/app/(protected)/page.tsx`(从 `src/app/page.tsx` 迁移)
+- Delete: `src/app/page.tsx`
+
+**目标:** 建立 `(protected)` 路由组,layout 拦截无 profile 的请求;封面页迁入。
+
+- [ ] **Step 1: 创建守卫 layout**
+
+写入 `src/app/(protected)/layout.tsx`:
+
+```tsx
+import { redirect } from 'next/navigation';
+import { getCoupleProfile } from '@/lib/actions';
+
+export const dynamic = 'force-dynamic';
+
+export default async function ProtectedLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  const profile = await getCoupleProfile();
+  if (!profile) {
+    redirect('/settings');
+  }
+  return <>{children}</>;
+}
+```
+
+- [ ] **Step 2: 把 src/app/page.tsx 迁到 (protected)/page.tsx,并去掉内联 redirect**
+
+写入 `src/app/(protected)/page.tsx`(注意:删除原文件第 17-19 行 `if (!profile) redirect('/settings')`,因为 layout 已守卫;`profile` 在该路径下保证非空):
+
+```tsx
+import Link from 'next/link';
+import dayjs from 'dayjs';
+import { getCoupleProfile, getCoverStats } from '@/lib/actions';
+import CoverLogo from '@/components/CoverLogo';
+import AnimatedDays from '@/components/AnimatedDays';
+import FloatingButton from '@/components/FloatingButton';
+
+export const dynamic = 'force-dynamic';
+
+export default async function Home() {
+  const [profile, stats] = await Promise.all([
+    getCoupleProfile(),
+    getCoverStats(),
+  ]);
+
+  // layout 守卫已确保 profile 存在
+  if (!profile) {
+    return null;
+  }
+
+  const days = dayjs().diff(dayjs(profile.anniversaryDate), 'day');
+  const formattedDate = dayjs(profile.anniversaryDate).format('YYYY.MM.DD');
+
+  return (
+    <div className="min-h-screen bg-cream px-4 relative">
+      <div className="mx-auto max-w-[480px] min-h-screen relative">
+        {/* 设置按钮 */}
+        <Link
+          href="/settings"
+          className="absolute top-4 right-0 p-2 text-text-sub hover:text-text-main transition-colors"
+          aria-label="设置"
+        >
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="12" cy="12" r="3" />
+            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
+          </svg>
+        </Link>
+
+        {/* Logo */}
+        <div className="absolute top-14 left-2">
+          <CoverLogo />
+        </div>
+
+        {/* 标题 */}
+        <div className="absolute top-16 left-16 text-[10px] text-text-sub tracking-[3px]">
+          恋爱小岛日记
+        </div>
+
+        {/* 昵称卡片 */}
+        <div className="absolute top-30 left-2 -rotate-2">
+          <div className="bg-card border border-border-soft rounded-xl px-5 py-3 shadow-sm">
+            <div className="text-[15px] font-bold text-text-main">
+              {profile.personAName}{' '}
+              <span className="text-accent">&</span>{' '}
+              {profile.personBName}
+            </div>
+            <div className="text-[9px] text-text-sub mt-1">
+              {formattedDate} — 至今
+            </div>
+          </div>
+        </div>
+
+        {/* 天数 */}
+        <div className="absolute top-50 right-6 text-right">
+          <AnimatedDays days={days} />
+          <div className="text-[11px] text-text-sub mt-1">天</div>
+        </div>
+
+        {/* 按钮 */}
+        <div className="absolute bottom-25 left-1/2 -translate-x-1/2">
+          <FloatingButton href="/diary">翻开日记</FloatingButton>
+        </div>
+
+        {/* 统计 */}
+        <div className="absolute bottom-6 right-6 text-[10px] text-text-sub">
+          日记 {stats.diaryCount} · 回忆 {stats.memoryCount}
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: 删除旧的 src/app/page.tsx**
+
+```bash
+rm src/app/page.tsx
+```
+
+- [ ] **Step 4: 跑 lint + build,确保路由结构有效**
+
+Run: `pnpm lint && pnpm build`
+Expected: lint 无报错;build 输出 `/` 与 `/settings` 两条路由,无 "you cannot have two parallel pages" 之类的冲突。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add -A
+git commit -m "feat(routing): (protected) 路由组 + layout 守卫,封面页迁入"
+```
+
+---
+
+## Task 5: SettingsForm 客户端组件
+
+**Files:**
+- Create: `src/components/SettingsForm.tsx`
+
+**目标:** Client Component,useActionState 接 Server Action,字段 + 错误反馈 + loading。
+
+- [ ] **Step 1: 创建组件**
+
+写入 `src/components/SettingsForm.tsx`:
+
+```tsx
+'use client';
+
+import Link from 'next/link';
+import { useActionState } from 'react';
+import { Input, Button } from 'animal-island-ui';
+import dayjs from 'dayjs';
+import {
+  saveCoupleProfileAction,
+  type SettingsFormState,
+} from '@/lib/actions';
+
+type Props = {
+  initial: {
+    personAName: string;
+    personBName: string;
+    anniversaryDate: Date;
+    siteTitle: string | null;
+  } | null;
+};
+
+const INITIAL_STATE: SettingsFormState = { ok: true };
+
+export default function SettingsForm({ initial }: Props) {
+  const [state, formAction, pending] = useActionState(
+    saveCoupleProfileAction,
+    INITIAL_STATE,
+  );
+
+  const isEdit = initial !== null;
+  const today = dayjs().format('YYYY-MM-DD');
+  const dateInputClass =
+    'w-full h-10 px-3 rounded-lg border border-border-soft bg-card text-text-main outline-none focus:border-accent';
+
+  return (
+    <div className="min-h-screen bg-cream px-4 py-8">
+      <div className="mx-auto max-w-[480px]">
+        <h1 className="text-2xl font-bold text-text-main">
+          {isEdit ? '修改情侣信息' : '告诉我们一些关于你们的事'}
+        </h1>
+        <p className="text-sm text-text-sub mt-2 mb-8">
+          {isEdit ? '调整后保存,封面会立即更新' : '先留下你们的基本信息'}
+        </p>
+
+        {state.formError && (
+          <div className="bg-red-50 border border-red-200 text-red-600 text-sm rounded-lg px-3 py-2 mb-4">
+            {state.formError}
+          </div>
+        )}
+
+        <form action={formAction} className="space-y-5">
+          <div>
+            <label
+              htmlFor="personAName"
+              className="block text-sm text-text-sub mb-1.5"
+            >
+              Ta 的昵称
+            </label>
+            <Input
+              id="personAName"
+              name="personAName"
+              defaultValue={initial?.personAName ?? ''}
+              maxLength={50}
+              required
+              status={state.fieldErrors?.personAName ? 'error' : undefined}
+              disabled={pending}
+            />
+            {state.fieldErrors?.personAName && (
+              <p className="text-xs text-red-500 mt-1">
+                {state.fieldErrors.personAName}
+              </p>
+            )}
+          </div>
+
+          <div>
+            <label
+              htmlFor="personBName"
+              className="block text-sm text-text-sub mb-1.5"
+            >
+              你的昵称
+            </label>
+            <Input
+              id="personBName"
+              name="personBName"
+              defaultValue={initial?.personBName ?? ''}
+              maxLength={50}
+              required
+              status={state.fieldErrors?.personBName ? 'error' : undefined}
+              disabled={pending}
+            />
+            {state.fieldErrors?.personBName && (
+              <p className="text-xs text-red-500 mt-1">
+                {state.fieldErrors.personBName}
+              </p>
+            )}
+          </div>
+
+          <div>
+            <label
+              htmlFor="anniversaryDate"
+              className="block text-sm text-text-sub mb-1.5"
+            >
+              在一起的日期
+            </label>
+            <input
+              type="date"
+              id="anniversaryDate"
+              name="anniversaryDate"
+              defaultValue={
+                initial
+                  ? dayjs(initial.anniversaryDate).format('YYYY-MM-DD')
+                  : ''
+              }
+              max={today}
+              required
+              disabled={pending}
+              className={dateInputClass}
+            />
+            {state.fieldErrors?.anniversaryDate && (
+              <p className="text-xs text-red-500 mt-1">
+                {state.fieldErrors.anniversaryDate}
+              </p>
+            )}
+          </div>
+
+          <div>
+            <label
+              htmlFor="siteTitle"
+              className="block text-sm text-text-sub mb-1.5"
+            >
+              网站标题（可选）
+            </label>
+            <Input
+              id="siteTitle"
+              name="siteTitle"
+              defaultValue={initial?.siteTitle ?? ''}
+              maxLength={100}
+              placeholder="恋爱小岛日记"
+              status={state.fieldErrors?.siteTitle ? 'error' : undefined}
+              disabled={pending}
+            />
+            {state.fieldErrors?.siteTitle && (
+              <p className="text-xs text-red-500 mt-1">
+                {state.fieldErrors.siteTitle}
+              </p>
+            )}
+          </div>
+
+          <Button
+            type="primary"
+            htmlType="submit"
+            block
+            loading={pending}
+            disabled={pending}
+          >
+            保存
+          </Button>
+        </form>
+
+        {isEdit && (
+          <Link
+            href="/"
+            className="text-center mt-4 block text-sm text-text-sub hover:text-text-main"
+          >
+            取消
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: 类型自检**
+
+Run: `pnpm lint`
+Expected: 无 ESLint / TS 报错(注意 `useActionState` 在 React 19 已 stable,types/react ^19 包含)。
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add src/components/SettingsForm.tsx
+git commit -m "feat(components): SettingsForm 客户端表单(useActionState)"
+```
+
+---
+
+## Task 6: 重写 settings 页(Server)
+
+**Files:**
+- Rewrite: `src/app/settings/page.tsx`
+
+**目标:** Server Component 取 profile,渲染 `<SettingsForm initial=...>`。
+
+- [ ] **Step 1: 用以下内容覆盖 src/app/settings/page.tsx**
+
+```tsx
+import { getCoupleProfile } from '@/lib/actions';
+import SettingsForm from '@/components/SettingsForm';
+
+export const dynamic = 'force-dynamic';
+
+export default async function SettingsPage() {
+  const profile = await getCoupleProfile();
+
+  const initial = profile
+    ? {
+        personAName: profile.personAName,
+        personBName: profile.personBName,
+        anniversaryDate: profile.anniversaryDate,
+        siteTitle: profile.siteTitle,
+      }
+    : null;
+
+  return <SettingsForm initial={initial} />;
+}
+```
+
+- [ ] **Step 2: build 与 lint**
+
+Run: `pnpm lint && pnpm build`
+Expected: 全部通过,build 输出 `/` 与 `/settings` 路由。
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add src/app/settings/page.tsx
+git commit -m "feat(settings): 设置页接入 SettingsForm,支持首次/编辑模式"
+```
+
+---
+
+## Task 7: 收尾验证
+
+**Files:** 无代码改动
+
+**目标:** 跑全套校验 + 手动验证 4 条流程。
+
+- [ ] **Step 1: 全套自动校验**
+
+Run:
+```bash
+pnpm lint
+pnpm test
+pnpm build
+```
+Expected: 全部 PASS,无警告/错误。
+
+- [ ] **Step 2: 手动验证流程 A — 首次引导**
+
+```bash
+rm -f prisma/dev.db
+pnpm prisma migrate deploy   # 应用既有 migrations 创建空 DB
+pnpm dev
+```
+
+浏览器打开 http://localhost:3000
+
+预期:
+1. `/` 自动跳转到 `/settings`
+2. 标题为"告诉我们一些关于你们的事"
+3. 无"取消"链接
+4. 提交空姓名 → 该字段下方显示"请填写..."
+5. 选未来日期 → input `max` 阻止;若手动 dispatch 表单,后端返回错误
+6. 填合法值提交 → 跳转回 `/`,封面正确显示
+
+- [ ] **Step 3: 手动验证流程 B — 再次进入(编辑模式)**
+
+继续不重启:
+1. 在封面右上角点齿轮进 `/settings`
+2. 标题变为"修改情侣信息"
+3. 字段已预填上一步的数据
+4. 底部显示"取消"链接,点击返回 `/`
+5. 修改昵称提交 → 跳回 `/`,新昵称生效
+6. 在终端 `sqlite3 prisma/dev.db 'SELECT COUNT(*) FROM CoupleProfile;'` → 应为 1
+
+- [ ] **Step 4: 手动验证流程 C — 守卫拦截**
+
+```bash
+rm -f prisma/dev.db
+pnpm prisma migrate deploy
+```
+
+重启 dev server 后:
+1. 直接访问 `/` → 跳到 `/settings`(layout 守卫起效)
+2. 直接访问 `/settings` → 渲染空表单,**不被拦截**(无死循环)
+
+- [ ] **Step 5: 提交收尾(若有 .gitignore 等小调整)**
+
+```bash
+git status
+# 若一切干净,跳过本步;若有未跟踪文件,审查后再决定是否提交
+```
+
+- [ ] **Step 6: 关闭 Issue 引用**
+
+无代码改动,留待 PR 合入主线后通过 PR 描述里 `Closes #5` 自动关闭。
+
+---
+
+## 备注
+
+- **redirect 在 Server Action 中的行为**:`redirect('/')` 通过抛出 `NEXT_REDIRECT` 错误实现跳转。Action 函数本应返回 `Promise<SettingsFormState>`,但抛出错误会终止函数,客户端 useActionState 不会更新 state,而是浏览器接收 307 跳到 `/`。测试中 `rejects.toThrow()` 即为预期。
+- **revalidatePath 在测试中**:由 `jest.mock('next/cache')` 替换为 noop,真实运行时则刷新封面缓存。
+- **路由组 `(protected)`**:括号语法不会出现在 URL 中,纯组织作用;放在 group 内的页面与外部页面共享根 layout。
+- **redirect 不可被 try/catch 包围**:伪代码已把 `redirect('/')` 放在 try/catch 之外,实施时务必保留该顺序。

--- a/docs/superpowers/specs/2026-05-02-settings-onboarding-design.md
+++ b/docs/superpowers/specs/2026-05-02-settings-onboarding-design.md
@@ -1,0 +1,339 @@
+# 设置页 + 首次引导 — 设计文档
+
+## 来源
+
+- Issue #5: [M2] 设置页 + 首次引导：CoupleProfile 表单 + 中间件重定向
+
+## 背景
+
+项目存储情侣双方的基本信息（昵称、在一起日期、网站标题）。首次访问无该数据时必须强制引导填写；之后允许修改。当前 `/settings` 仅是占位页，封面 `/` 已有内联的 `redirect('/settings')` 检查，但其他后续路由（`/diary` 等尚未实现）需要统一拦截策略。
+
+## 决策摘要
+
+| 决策点 | 选定方案 | 备选 |
+|---|---|---|
+| 拦截层 | (protected) 路由组 + Server Component layout 守卫 | nodejs middleware / 逐页自检 |
+| 表单提交 | React 19 `useActionState` + Server Action 接 FormData | useState + onSubmit |
+| 路由组迁移 | 将现有 `/` 封面页迁入 `(protected)`，删除其内联 redirect | 仅为未来路由设 layout |
+| 日期控件 | 原生 `<input type="date">` | animal-island-ui Select 拼装 |
+
+## 架构
+
+### 路由结构
+
+```
+src/app/
+├── layout.tsx                  # 根布局（不变）
+├── (protected)/
+│   ├── layout.tsx              # 新增：getCoupleProfile() 缺失则 redirect('/settings')
+│   └── page.tsx                # 从 src/app/page.tsx 迁入；删除内联 redirect
+└── settings/
+    └── page.tsx                # 重写：Server Component + 客户端表单
+```
+
+`(protected)/layout.tsx` 是 Server Component，每次请求执行一次 `getCoupleProfile()`。`/settings` 物理上不在该 group 内，天然规避死循环。后续 `/diary`、`/diary/[id]`、`/memories`、`/calendar` 等需要 profile 的路由直接迁入 `(protected)/` 即可复用守卫。
+
+### 组件拆分
+
+| 文件 | 类型 | 职责 |
+|------|------|------|
+| `src/app/(protected)/layout.tsx` | Server | 调用 `getCoupleProfile()`；缺失则 `redirect('/settings')` |
+| `src/app/(protected)/page.tsx` | Server | 封面页（迁移自 `src/app/page.tsx`，移除内部 redirect 与重复检查） |
+| `src/app/settings/page.tsx` | Server | 取 profile，渲染 `<SettingsForm initial={profile ?? null} />` |
+| `src/components/SettingsForm.tsx` | Client | `useActionState` 调用 action；字段输入；错误展示；loading |
+| `src/lib/actions.ts` | Server | 新增 `saveCoupleProfileAction(prevState, formData)`；保留并复用既有 `updateCoupleProfile` |
+
+## 数据流
+
+```
+用户访问任意 (protected) 路径
+   ↓
+(protected)/layout.tsx 执行 getCoupleProfile()
+   ↓
+   ├── profile 存在 → 渲染子页面
+   └── profile 不存在 → redirect('/settings')
+
+用户访问 /settings
+   ↓
+settings/page.tsx 执行 getCoupleProfile()
+   ↓
+   ├── profile 存在 → 渲染 SettingsForm（编辑模式，预填）
+   └── profile 不存在 → 渲染 SettingsForm（首次模式，空表单）
+
+用户提交表单
+   ↓
+saveCoupleProfileAction(prevState, formData)
+   ↓
+   ├── zod 校验失败 → return { ok: false, fieldErrors }
+   ├── 未来日期 → return { ok: false, fieldErrors: { anniversaryDate } }
+   ├── DB 异常 → return { ok: false, formError: '保存失败,请稍后重试' }
+   └── 成功 → revalidatePath('/') + redirect('/')
+```
+
+## Server Action
+
+### 函数签名
+
+```ts
+type SettingsFormState = {
+  ok: boolean;
+  fieldErrors?: Partial<Record<
+    'personAName' | 'personBName' | 'anniversaryDate' | 'siteTitle',
+    string
+  >>;
+  formError?: string;
+};
+
+export async function saveCoupleProfileAction(
+  _prev: SettingsFormState,
+  formData: FormData,
+): Promise<SettingsFormState>;
+```
+
+### 校验逻辑
+
+1. 从 FormData 取 4 字段：personAName, personBName, anniversaryDate, siteTitle
+2. 用 action 内构建的 `ActionSchema`（含 trim、自定义错误信息、未来日期 refine）`safeParse`
+3. 任一失败 → 收集 zod issue 到 `fieldErrors`，返回 `{ ok: false, fieldErrors }`
+4. 全部通过 → 把 trim 后为空字符串的 `siteTitle` 归一化为 `undefined`（避免下游 DB 存空串），然后调用既有 `updateCoupleProfile(normalized)`
+5. DB 异常 → 捕获返回 `{ ok: false, formError: '保存失败,请稍后重试' }`
+6. 成功 → `revalidatePath('/')`，最后 `redirect('/')`
+
+> `redirect('/')` 必须在 try/catch 之外。Next.js 通过抛出 NEXT_REDIRECT 错误实现页面跳转，若被通用 catch 吞掉会导致 Action 静默返回，浏览器停留在表单页。
+
+### 控制流伪代码
+
+```ts
+const parsed = ActionSchema.safeParse({
+  personAName: formData.get('personAName'),
+  personBName: formData.get('personBName'),
+  anniversaryDate: formData.get('anniversaryDate'),
+  siteTitle: formData.get('siteTitle'),
+});
+
+if (!parsed.success) {
+  return { ok: false, fieldErrors: zodIssuesToFieldErrors(parsed.error) };
+}
+
+const data = {
+  ...parsed.data,
+  siteTitle: parsed.data.siteTitle?.length ? parsed.data.siteTitle : undefined,
+};
+
+try {
+  await updateCoupleProfile(data);
+} catch {
+  return { ok: false, formError: '保存失败,请稍后重试' };
+}
+
+revalidatePath('/');
+redirect('/');
+```
+
+### Schema 增量
+
+`src/lib/schemas.ts` 中既有 `CoupleProfileSchema`：
+
+```ts
+export const CoupleProfileSchema = z.object({
+  personAName: z.string().min(1).max(50),
+  personBName: z.string().min(1).max(50),
+  anniversaryDate: z.coerce.date(),
+  siteTitle: z.string().max(100).optional(),
+});
+```
+
+在 action 内独立构造一份增强版 schema（不污染 schemas.ts 的纯结构定义，本地承担用户友好错误信息和业务规则）：
+
+```ts
+const ActionSchema = z.object({
+  personAName: z.string().trim().min(1, '请填写第一位的昵称').max(50, '不超过 50 字'),
+  personBName: z.string().trim().min(1, '请填写第二位的昵称').max(50, '不超过 50 字'),
+  anniversaryDate: z.coerce
+    .date({ error: '请选择日期' })
+    .refine((d) => d.getTime() <= Date.now(), '在一起日期不能晚于今天'),
+  siteTitle: z.string().trim().max(100, '不超过 100 字').optional(),
+});
+```
+
+> 优先使用 `trim().min(1)` 而非 `nonempty()`,避免全空白通过校验;`siteTitle` 在 action 内将 trim 后空串归一化为 undefined,确保数据库存 null。
+
+## SettingsForm 组件
+
+### Props
+
+```ts
+type Props = {
+  initial: {
+    personAName: string;
+    personBName: string;
+    anniversaryDate: Date;
+    siteTitle: string | null;
+  } | null;
+};
+```
+
+### 行为
+
+- `useActionState(saveCoupleProfileAction, { ok: true })` 取 `[state, formAction, pending]`
+- `<form action={formAction}>` 直接对接 Server Action
+- 各字段使用 `defaultValue={initial?.x}` 而非受控 state（提交时由 FormData 收集）
+- 错误从 `state.fieldErrors[name]` 取，红色小字显示在该 Input 下方
+- 顶部 `state.formError` 显示通用错误条幅
+- `<Button loading={pending} disabled={pending}>` 防重复点击
+- 标题区根据 `initial` 是否为 null 切换：
+  - `null` → "告诉我们一些关于你们的事" + 副标题"先留下你们的基本信息"
+  - 非 null → "修改情侣信息" + 副标题"调整后保存,封面会立即更新"
+
+### 布局
+
+```
+┌────────────────────────────────┐
+│  告诉我们一些关于你们的事        │  ← h1 跳跳体 大字
+│  先留下你们的基本信息            │  ← p 次级文字
+│                                │
+│  [Top Banner 错误条幅 (条件)]   │
+│                                │
+│  Ta 的昵称                      │
+│  [ Input personAName        ]  │
+│  [字段错误,如有]                │
+│                                │
+│  你的昵称                       │
+│  [ Input personBName        ]  │
+│  [字段错误,如有]                │
+│                                │
+│  在一起的日期                   │
+│  [ <input type=date>         ] │
+│  [字段错误,如有]                │
+│                                │
+│  网站标题（可选）               │
+│  [ Input siteTitle          ]  │
+│                                │
+│  [    保存（Button block）     ]│
+│                                │
+│  ← 取消（仅编辑模式）           │
+└────────────────────────────────┘
+```
+
+### CSS / Tailwind
+
+- 容器：`min-h-screen bg-cream px-4 py-8`
+- 内层：`mx-auto max-w-[480px]`
+- 标题：`text-2xl font-bold text-text-main`
+- 副标题：`text-sm text-text-sub mt-2 mb-8`
+- 字段组：`space-y-5`
+- 字段标签：`block text-sm text-text-sub mb-1.5`
+- 字段错误：`text-xs text-red-500 mt-1`
+- 顶部错误条幅：`bg-red-50 border border-red-200 text-red-600 text-sm rounded-lg px-3 py-2 mb-4`
+- 日期 input：补一个 className 让它和 animal-island-ui Input 视觉对齐(`w-full h-10 px-3 rounded-lg border border-border-soft bg-card text-text-main`)
+- 保存按钮：`block` 撑满
+- 取消链接：`text-center mt-4 block text-sm text-text-sub hover:text-text-main`
+
+## 边界情况
+
+| 场景 | 行为 |
+|------|------|
+| 名字 trim 后为空 | zod trim().min(1)，下方："请填写昵称" |
+| 名字超 50 字符 | `<Input maxLength={50}>` 客户端阻止 + zod 兜底 |
+| anniversaryDate 未来日期 | `<input max={today}>` 客户端阻止 + zod refine 兜底，下方："在一起日期不能晚于今天" |
+| anniversaryDate 留空 | HTML required + zod coerce 失败，下方："请选择日期" |
+| siteTitle 超 100 字符 | `maxLength={100}` 限制 |
+| siteTitle 留空 | 允许，存 null（schema optional），下游用默认"恋爱小岛日记" |
+| 提交期间再次点击 | `Button.loading={pending}` + `disabled={pending}` 双重保护 |
+| Server Action DB 异常 | 顶部红色条幅 "保存失败,请稍后重试"；表单内字段值保留（defaultValue 不变） |
+| 保存成功 | `revalidatePath('/')` + `redirect('/')`，封面立即取最新 profile |
+| 编辑模式预填后立即保存 | 同 update 路径，updatedAt 自动刷新 |
+| 用户已设置后访问 `/settings` | 渲染编辑模式 |
+| 跳过 (protected) layout | layout.tsx 必经，无法绕过；任何 `(protected)/**` 子路由都被守卫 |
+| profile 存在但姓名为空（脏数据） | 编辑模式预填空字符串，提交时被 trim().min(1) 拦下 |
+| 用户在编辑页直接修改 URL 跳到 `/settings` | 不在 (protected) 内，无守卫，正常渲染 |
+| 同一时刻多个标签页同时编辑 | upsert 单例 id='profile'，最后保存者胜出（业务可接受） |
+
+## 测试
+
+仅扩展 Server Action 行为，组件层（client useActionState）测试成本高且当前未配置 RTL，本期跳过。
+
+`src/lib/__tests__/actions.test.ts` 中 `describe('CoupleProfile Actions')` 增补：
+
+```ts
+describe('saveCoupleProfileAction', () => {
+  test('拒绝未来日期', async () => {
+    const fd = new FormData();
+    fd.set('personAName', '小兔子');
+    fd.set('personBName', '大灰狼');
+    fd.set('anniversaryDate', dayjs().add(1, 'day').format('YYYY-MM-DD'));
+    const state = await saveCoupleProfileAction({ ok: true }, fd);
+    expect(state.ok).toBe(false);
+    expect(state.fieldErrors?.anniversaryDate).toBeTruthy();
+  });
+
+  test('拒绝空白姓名', async () => {
+    const fd = new FormData();
+    fd.set('personAName', '   ');
+    fd.set('personBName', '大灰狼');
+    fd.set('anniversaryDate', '2024-07-18');
+    const state = await saveCoupleProfileAction({ ok: true }, fd);
+    expect(state.ok).toBe(false);
+    expect(state.fieldErrors?.personAName).toBeTruthy();
+  });
+
+  test('成功路径调用 updateCoupleProfile', async () => {
+    const fd = new FormData();
+    fd.set('personAName', '小兔子');
+    fd.set('personBName', '大灰狼');
+    fd.set('anniversaryDate', '2024-07-18');
+    fd.set('siteTitle', '恋爱小岛日记');
+    // 预期 redirect 抛出 NEXT_REDIRECT，捕获即可
+    await expect(saveCoupleProfileAction({ ok: true }, fd)).rejects.toThrow();
+    const profile = await prisma.coupleProfile.findFirst();
+    expect(profile?.personAName).toBe('小兔子');
+  });
+});
+```
+
+> redirect() 在 Server Action 中通过抛出特殊错误实现页面跳转，测试中 `rejects.toThrow()` 是预期行为，并非 bug。
+
+## 与 Issue #5 验收映射
+
+| Issue 验收项 | 实现位置 |
+|---|---|
+| 首次访问 `/` 不存在则重定向 `/settings` | `src/app/(protected)/layout.tsx` |
+| 设置页表单 4 字段 | `SettingsForm.tsx` |
+| 提交后创建 CoupleProfile | `saveCoupleProfileAction` → `updateCoupleProfile`（upsert） |
+| 创建成功后跳转到 `/` | action 内 `redirect('/')` |
+| 已设置后访问 `/settings` 可以修改 | `settings/page.tsx` 取 profile 作为 `initial` |
+| 修改后 updatedAt 自动更新 | Prisma `@updatedAt` 装饰器 |
+| 使用 animal-island-ui Input | `personAName/personBName/siteTitle` 三个 Input |
+| 日期选择器使用原生 date input | `<input type="date">` 自定义样式 |
+| 保存按钮有 loading 状态 | `Button loading={pending}` |
+| 表单校验失败时显示错误提示 | 字段下方 + 顶部条幅双层 |
+| 中间件对 `/settings` 自身不重定向 | route group 物理隔离，无环 |
+| 空昵称提交时显示校验错误 | zod trim().min(1) |
+| 未来日期不允许选择 | input `max` + zod refine 双重防护 |
+| 中间件重定向逻辑测试 | layout 可走 e2e；本期通过 action 单测覆盖核心校验 |
+| 表单校验逻辑测试 | actions.test.ts 三个新增用例 |
+
+## 不在范围
+
+- 访问密码（Issue #14）
+- 主题切换、备份路径（P2）
+- 头像/插画上传（P2）
+- 国际化（暂仅简中）
+
+## 实施步骤概览
+
+1. 新增 `src/app/(protected)/layout.tsx`（守卫）
+2. 移动 `src/app/page.tsx` → `src/app/(protected)/page.tsx`，删除其内部 redirect 调用
+3. `src/lib/actions.ts` 新增 `saveCoupleProfileAction`（含 zod refine、redirect、revalidatePath）
+4. 新增 `src/components/SettingsForm.tsx`（client）
+5. 重写 `src/app/settings/page.tsx`（server，注入 initial）
+6. `actions.test.ts` 新增 3 个测试用例
+7. `pnpm lint`、`pnpm test`、`pnpm build` 全绿
+8. 手动验证：清空 DB → 访问 `/` 重定向 → 填表 → 跳回封面；再次访问 `/settings` 进入编辑模式；提交修改 → 跳回封面；DB count 仍为 1
+
+## 风险与注意
+
+- redirect() 必须在 try/catch 之外抛出，否则 NEXT_REDIRECT 错误会被吞
+- 若 `(protected)/layout.tsx` 内 `getCoupleProfile()` 因 DB 文件不可读抛错，目前会冒泡为 500；后续可加错误兜底页（不在本期范围）
+- 原生 date input 在不同浏览器表现不一致（移动端 iOS/Android 一致体验良好，桌面端样式保留浏览器默认）；可接受
+- useActionState 是 React 19 stable API，依赖 react@19 ✓ 已在 package.json

--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -1,0 +1,14 @@
+import { redirect } from 'next/navigation';
+import { getCoupleProfile } from '@/lib/actions';
+
+export const dynamic = 'force-dynamic';
+
+export default async function ProtectedLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  const profile = await getCoupleProfile();
+  if (!profile) {
+    redirect('/settings');
+  }
+  return <>{children}</>;
+}

--- a/src/app/(protected)/page.tsx
+++ b/src/app/(protected)/page.tsx
@@ -13,7 +13,7 @@ export default async function Home() {
     getCoverStats(),
   ]);
 
-  // layout 守卫已确保 profile 存在
+  // layout 守卫已确保 profile 存在;保留类型收窄
   if (!profile) {
     return null;
   }

--- a/src/app/(protected)/page.tsx
+++ b/src/app/(protected)/page.tsx
@@ -1,5 +1,4 @@
 import Link from 'next/link';
-import { redirect } from 'next/navigation';
 import dayjs from 'dayjs';
 import { getCoupleProfile, getCoverStats } from '@/lib/actions';
 import CoverLogo from '@/components/CoverLogo';
@@ -14,8 +13,9 @@ export default async function Home() {
     getCoverStats(),
   ]);
 
+  // layout 守卫已确保 profile 存在
   if (!profile) {
-    redirect('/settings');
+    return null;
   }
 
   const days = dayjs().diff(dayjs(profile.anniversaryDate), 'day');

--- a/src/app/(protected)/page.tsx
+++ b/src/app/(protected)/page.tsx
@@ -52,7 +52,7 @@ export default async function Home() {
 
         {/* 标题 */}
         <div className="absolute top-16 left-16 text-[10px] text-text-sub tracking-[3px]">
-          恋爱小岛日记
+          {profile.siteTitle ?? '恋爱小岛日记'}
         </div>
 
         {/* 昵称卡片 */}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,10 +1,19 @@
-export default function SettingsPage() {
-  return (
-    <div className="min-h-screen bg-cream flex items-center justify-center px-4">
-      <div className="text-center">
-        <h1 className="text-2xl font-bold text-text-main">设置</h1>
-        <p className="text-text-sub mt-2">设置页开发中...</p>
-      </div>
-    </div>
-  );
+import { getCoupleProfile } from '@/lib/actions';
+import SettingsForm from '@/components/SettingsForm';
+
+export const dynamic = 'force-dynamic';
+
+export default async function SettingsPage() {
+  const profile = await getCoupleProfile();
+
+  const initial = profile
+    ? {
+        personAName: profile.personAName,
+        personBName: profile.personBName,
+        anniversaryDate: profile.anniversaryDate,
+        siteTitle: profile.siteTitle,
+      }
+    : null;
+
+  return <SettingsForm initial={initial} />;
 }

--- a/src/components/AnimatedDays.tsx
+++ b/src/components/AnimatedDays.tsx
@@ -15,7 +15,7 @@ export default function AnimatedDays({ days }: AnimatedDaysProps) {
   );
   const spring = useSpring(0, { duration: 1500 });
   const display = useTransform(spring, (v) => Math.round(v));
-  const prevDaysRef = useRef(days);
+  const prevDaysRef = useRef<number | null>(null);
 
   useEffect(() => {
     const mql = window.matchMedia('(prefers-reduced-motion: reduce)');

--- a/src/components/SettingsForm.tsx
+++ b/src/components/SettingsForm.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import Link from 'next/link';
+import { useActionState } from 'react';
+import { Input, Button } from 'animal-island-ui';
+import dayjs from 'dayjs';
+import {
+  saveCoupleProfileAction,
+  type SettingsFormState,
+} from '@/lib/actions';
+
+type Props = {
+  initial: {
+    personAName: string;
+    personBName: string;
+    anniversaryDate: Date;
+    siteTitle: string | null;
+  } | null;
+};
+
+const INITIAL_STATE: SettingsFormState = { ok: true };
+
+export default function SettingsForm({ initial }: Props) {
+  const [state, formAction, pending] = useActionState(
+    saveCoupleProfileAction,
+    INITIAL_STATE,
+  );
+
+  const isEdit = initial !== null;
+  const today = dayjs().format('YYYY-MM-DD');
+  const dateInputClass =
+    'w-full h-10 px-3 rounded-lg border border-border-soft bg-card text-text-main outline-none focus:border-accent';
+
+  return (
+    <div className="min-h-screen bg-cream px-4 py-8">
+      <div className="mx-auto max-w-[480px]">
+        <h1 className="text-2xl font-bold text-text-main">
+          {isEdit ? '修改情侣信息' : '告诉我们一些关于你们的事'}
+        </h1>
+        <p className="text-sm text-text-sub mt-2 mb-8">
+          {isEdit ? '调整后保存,封面会立即更新' : '先留下你们的基本信息'}
+        </p>
+
+        {state.formError && (
+          <div className="bg-red-50 border border-red-200 text-red-600 text-sm rounded-lg px-3 py-2 mb-4">
+            {state.formError}
+          </div>
+        )}
+
+        <form action={formAction} className="space-y-5">
+          <div>
+            <label
+              htmlFor="personAName"
+              className="block text-sm text-text-sub mb-1.5"
+            >
+              Ta 的昵称
+            </label>
+            <Input
+              id="personAName"
+              name="personAName"
+              defaultValue={initial?.personAName ?? ''}
+              maxLength={50}
+              required
+              status={state.fieldErrors?.personAName ? 'error' : undefined}
+              disabled={pending}
+            />
+            {state.fieldErrors?.personAName && (
+              <p className="text-xs text-red-500 mt-1">
+                {state.fieldErrors.personAName}
+              </p>
+            )}
+          </div>
+
+          <div>
+            <label
+              htmlFor="personBName"
+              className="block text-sm text-text-sub mb-1.5"
+            >
+              你的昵称
+            </label>
+            <Input
+              id="personBName"
+              name="personBName"
+              defaultValue={initial?.personBName ?? ''}
+              maxLength={50}
+              required
+              status={state.fieldErrors?.personBName ? 'error' : undefined}
+              disabled={pending}
+            />
+            {state.fieldErrors?.personBName && (
+              <p className="text-xs text-red-500 mt-1">
+                {state.fieldErrors.personBName}
+              </p>
+            )}
+          </div>
+
+          <div>
+            <label
+              htmlFor="anniversaryDate"
+              className="block text-sm text-text-sub mb-1.5"
+            >
+              在一起的日期
+            </label>
+            <input
+              type="date"
+              id="anniversaryDate"
+              name="anniversaryDate"
+              defaultValue={
+                initial
+                  ? dayjs(initial.anniversaryDate).format('YYYY-MM-DD')
+                  : ''
+              }
+              max={today}
+              required
+              disabled={pending}
+              className={dateInputClass}
+            />
+            {state.fieldErrors?.anniversaryDate && (
+              <p className="text-xs text-red-500 mt-1">
+                {state.fieldErrors.anniversaryDate}
+              </p>
+            )}
+          </div>
+
+          <div>
+            <label
+              htmlFor="siteTitle"
+              className="block text-sm text-text-sub mb-1.5"
+            >
+              网站标题（可选）
+            </label>
+            <Input
+              id="siteTitle"
+              name="siteTitle"
+              defaultValue={initial?.siteTitle ?? ''}
+              maxLength={100}
+              placeholder="恋爱小岛日记"
+              status={state.fieldErrors?.siteTitle ? 'error' : undefined}
+              disabled={pending}
+            />
+            {state.fieldErrors?.siteTitle && (
+              <p className="text-xs text-red-500 mt-1">
+                {state.fieldErrors.siteTitle}
+              </p>
+            )}
+          </div>
+
+          <Button
+            type="primary"
+            htmlType="submit"
+            block
+            loading={pending}
+            disabled={pending}
+          >
+            保存
+          </Button>
+        </form>
+
+        {isEdit && (
+          <Link
+            href="/"
+            className="text-center mt-4 block text-sm text-text-sub hover:text-text-main"
+          >
+            取消
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/__tests__/actions.test.ts
+++ b/src/lib/__tests__/actions.test.ts
@@ -261,4 +261,17 @@ describe('saveCoupleProfileAction', () => {
     expect(state.ok).toBe(false);
     expect(state.fieldErrors?.anniversaryDate).toBe('在一起日期不能晚于今天');
   });
+
+  test('拒绝空白姓名(trim 后为空)', async () => {
+    const fd = new FormData();
+    fd.set('personAName', '   ');
+    fd.set('personBName', '大灰狼');
+    fd.set('anniversaryDate', '2024-07-18');
+    fd.set('siteTitle', '');
+
+    const state = await saveCoupleProfileAction({ ok: true }, fd);
+
+    expect(state.ok).toBe(false);
+    expect(state.fieldErrors?.personAName).toBe('请填写第一位的昵称');
+  });
 });

--- a/src/lib/__tests__/actions.test.ts
+++ b/src/lib/__tests__/actions.test.ts
@@ -274,4 +274,36 @@ describe('saveCoupleProfileAction', () => {
     expect(state.ok).toBe(false);
     expect(state.fieldErrors?.personAName).toBe('请填写第一位的昵称');
   });
+
+  test('成功路径写入 profile 并 redirect 到 /', async () => {
+    const fd = new FormData();
+    fd.set('personAName', '小兔子');
+    fd.set('personBName', '大灰狼');
+    fd.set('anniversaryDate', '2024-07-18');
+    fd.set('siteTitle', '恋爱小岛日记');
+
+    await expect(
+      saveCoupleProfileAction({ ok: true }, fd),
+    ).rejects.toThrow('NEXT_REDIRECT:/');
+
+    const profile = await prisma.coupleProfile.findFirst();
+    expect(profile?.personAName).toBe('小兔子');
+    expect(profile?.personBName).toBe('大灰狼');
+    expect(profile?.siteTitle).toBe('恋爱小岛日记');
+  });
+
+  test('成功路径下空白 siteTitle 归一化为 null', async () => {
+    const fd = new FormData();
+    fd.set('personAName', '小兔子');
+    fd.set('personBName', '大灰狼');
+    fd.set('anniversaryDate', '2024-07-18');
+    fd.set('siteTitle', '   ');
+
+    await expect(
+      saveCoupleProfileAction({ ok: true }, fd),
+    ).rejects.toThrow('NEXT_REDIRECT:/');
+
+    const profile = await prisma.coupleProfile.findFirst();
+    expect(profile?.siteTitle).toBeNull();
+  });
 });

--- a/src/lib/__tests__/actions.test.ts
+++ b/src/lib/__tests__/actions.test.ts
@@ -9,7 +9,18 @@ import {
   getCoupleProfile,
   updateCoupleProfile,
   getCoverStats,
+  saveCoupleProfileAction,
 } from '../actions';
+import dayjs from 'dayjs';
+
+jest.mock('next/cache', () => ({ revalidatePath: jest.fn() }));
+jest.mock('next/navigation', () => ({
+  redirect: (url: string) => {
+    const err = new Error(`NEXT_REDIRECT:${url}`);
+    (err as Error & { digest?: string }).digest = `NEXT_REDIRECT;replace;${url};307;`;
+    throw err;
+  },
+}));
 
 beforeEach(async () => {
   await prisma.diaryImage.deleteMany();
@@ -234,5 +245,20 @@ describe('Cover Stats', () => {
     const stats = await getCoverStats();
     expect(stats.diaryCount).toBe(2);
     expect(stats.memoryCount).toBe(2);
+  });
+});
+
+describe('saveCoupleProfileAction', () => {
+  test('拒绝未来日期', async () => {
+    const fd = new FormData();
+    fd.set('personAName', '小兔子');
+    fd.set('personBName', '大灰狼');
+    fd.set('anniversaryDate', dayjs().add(1, 'day').format('YYYY-MM-DD'));
+    fd.set('siteTitle', '');
+
+    const state = await saveCoupleProfileAction({ ok: true }, fd);
+
+    expect(state.ok).toBe(false);
+    expect(state.fieldErrors?.anniversaryDate).toBe('在一起日期不能晚于今天');
   });
 });

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -12,6 +12,7 @@ import {
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { z } from 'zod';
+import dayjs from 'dayjs';
 
 export async function createDiary(data: CreateDiaryInput) {
   const parsed = CreateDiarySchema.parse(data);
@@ -169,8 +170,17 @@ const SettingsActionSchema = z.object({
     .max(50, '不超过 50 字'),
   anniversaryDate: z.coerce
     .date({ error: '请选择日期' })
-    .refine((d) => d.getTime() <= Date.now(), '在一起日期不能晚于今天'),
-  siteTitle: z.string().trim().max(100, '不超过 100 字').optional(),
+    .refine(
+      (d) =>
+        dayjs(d).startOf('day').valueOf() <= dayjs().endOf('day').valueOf(),
+      '在一起日期不能晚于今天',
+    ),
+  siteTitle: z
+    .string()
+    .trim()
+    .max(100, '不超过 100 字')
+    .transform((v) => (v.length ? v : null))
+    .optional(),
 });
 
 function zodIssuesToFieldErrors(
@@ -205,13 +215,8 @@ export async function saveCoupleProfileAction(
     return { ok: false, fieldErrors: zodIssuesToFieldErrors(parsed.error) };
   }
 
-  const data = {
-    ...parsed.data,
-    siteTitle: parsed.data.siteTitle?.length ? parsed.data.siteTitle : undefined,
-  };
-
   try {
-    await updateCoupleProfile(data);
+    await updateCoupleProfile(parsed.data);
   } catch {
     return { ok: false, formError: '保存失败,请稍后重试' };
   }

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -9,6 +9,9 @@ import {
   type UpdateDiaryInput,
   type CoupleProfileInput,
 } from './schemas';
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+import { z } from 'zod';
 
 export async function createDiary(data: CreateDiaryInput) {
   const parsed = CreateDiarySchema.parse(data);
@@ -143,4 +146,76 @@ export async function getCoverStats() {
     prisma.diaryImage.count(),
   ]);
   return { diaryCount, memoryCount };
+}
+
+export type SettingsFormState = {
+  ok: boolean;
+  fieldErrors?: Partial<
+    Record<'personAName' | 'personBName' | 'anniversaryDate' | 'siteTitle', string>
+  >;
+  formError?: string;
+};
+
+const SettingsActionSchema = z.object({
+  personAName: z
+    .string()
+    .trim()
+    .min(1, '请填写第一位的昵称')
+    .max(50, '不超过 50 字'),
+  personBName: z
+    .string()
+    .trim()
+    .min(1, '请填写第二位的昵称')
+    .max(50, '不超过 50 字'),
+  anniversaryDate: z.coerce
+    .date({ error: '请选择日期' })
+    .refine((d) => d.getTime() <= Date.now(), '在一起日期不能晚于今天'),
+  siteTitle: z.string().trim().max(100, '不超过 100 字').optional(),
+});
+
+function zodIssuesToFieldErrors(
+  error: z.ZodError,
+): SettingsFormState['fieldErrors'] {
+  const fieldErrors: SettingsFormState['fieldErrors'] = {};
+  for (const issue of error.issues) {
+    const key = issue.path[0];
+    if (
+      typeof key === 'string' &&
+      ['personAName', 'personBName', 'anniversaryDate', 'siteTitle'].includes(key)
+    ) {
+      const k = key as keyof NonNullable<SettingsFormState['fieldErrors']>;
+      if (!fieldErrors[k]) fieldErrors[k] = issue.message;
+    }
+  }
+  return fieldErrors;
+}
+
+export async function saveCoupleProfileAction(
+  _prev: SettingsFormState,
+  formData: FormData,
+): Promise<SettingsFormState> {
+  const parsed = SettingsActionSchema.safeParse({
+    personAName: formData.get('personAName'),
+    personBName: formData.get('personBName'),
+    anniversaryDate: formData.get('anniversaryDate'),
+    siteTitle: formData.get('siteTitle'),
+  });
+
+  if (!parsed.success) {
+    return { ok: false, fieldErrors: zodIssuesToFieldErrors(parsed.error) };
+  }
+
+  const data = {
+    ...parsed.data,
+    siteTitle: parsed.data.siteTitle?.length ? parsed.data.siteTitle : undefined,
+  };
+
+  try {
+    await updateCoupleProfile(data);
+  } catch {
+    return { ok: false, formError: '保存失败,请稍后重试' };
+  }
+
+  revalidatePath('/');
+  redirect('/');
 }

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -18,7 +18,7 @@ export const CoupleProfileSchema = z.object({
   personAName: z.string().min(1).max(50),
   personBName: z.string().min(1).max(50),
   anniversaryDate: z.coerce.date(),
-  siteTitle: z.string().max(100).optional(),
+  siteTitle: z.string().max(100).nullable().optional(),
 });
 
 export type CoupleProfileInput = z.infer<typeof CoupleProfileSchema>;


### PR DESCRIPTION
## Summary

- 新增 `(protected)` 路由组,layout 守卫在无 CoupleProfile 时自动跳转 `/settings`
- 重写 `/settings` 页:Server Component + `SettingsForm` Client Component(useActionState)
- 新增 `saveCoupleProfileAction`:zod 校验(trim/日级比较/siteTitle 归一化) + upsert + revalidate + redirect
- 封面页标题改为读取 `profile.siteTitle`,支持自定义
- 修复 `AnimatedDays` 首次渲染动画不触发的问题
- 补充 4 个 action 测试用例(19/19 全部通过)

## Test Plan

- [x] `pnpm lint` 通过
- [x] `pnpm test` 19 passed / 19
- [x] `pnpm build` 通过,路由 `/` + `/settings` 无冲突
- [x] 清空 DB 后访问 `/` 自动跳转 `/settings`
- [x] 首次填写表单提交后创建 profile 并跳转 `/`
- [x] 再次访问 `/settings` 进入编辑模式,字段预填,可修改
- [x] 空白昵称/未来日期被拦截并显示错误
- [x] siteTitle 留空或纯空格时归一化为 null

Closes #5