### PR TITLE
[M2] 新增日记页：表单 + 心情选择器 + 外链图片 + 草稿自动保存

### DIFF
--- a/docs/superpowers/plans/2026-05-03-diary-new-page.md
+++ b/docs/superpowers/plans/2026-05-03-diary-new-page.md
@@ -1,0 +1,1149 @@
+# 新增日记页 + 极简详情页 实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 实现 `/diary/new` 新增日记表单（含心情选择器、外链图片、草稿自动保存）以及 `/diary/[id]` 极简详情页占位。
+
+**Architecture:** Client Component 表单用 `useState` + 自定义 `useDiaryDraft` hook 管理状态与草稿，子组件 `MoodSelector`、`ImageUrlInput` 独立封装。表单提交调用已有 `createDiary` Server Action，成功后清草稿并客户端路由跳转。极简详情页为 Server Component，直接查库渲染。
+
+**Tech Stack:** Next.js 16 App Router、React 19、Tailwind CSS v4、animal-island-ui、Jest + ts-jest + React Testing Library、Prisma、zod。
+
+**Spec:** `docs/superpowers/specs/2026-05-03-diary-new-page-design.md`
+
+---
+
+## File Structure
+
+| 文件 | 操作 | 职责 |
+|------|------|------|
+| `jest.config.ts` | 修改 | 支持 `.test.tsx` 与 `jsdom` 环境 |
+| `src/lib/test-setup.ts` | 修改 | 追加 `@testing-library/jest-dom` 引入 |
+| `src/hooks/useDiaryDraft.ts` | 创建 | localStorage 草稿自动保存 hook |
+| `src/hooks/__tests__/useDiaryDraft.test.ts` | 创建 | hook 单元测试 |
+| `src/components/MoodSelector.tsx` | 创建 | 心情下拉选择器 |
+| `src/components/__tests__/MoodSelector.test.tsx` | 创建 | 组件单元测试 |
+| `src/components/ImageUrlInput.tsx` | 创建 | 图片 URL 动态列表 |
+| `src/components/__tests__/ImageUrlInput.test.tsx` | 创建 | 组件单元测试 |
+| `src/components/DiaryForm.validation.ts` | 创建 | 表单校验纯函数 |
+| `src/components/__tests__/DiaryForm.validation.test.ts` | 创建 | 校验逻辑单元测试 |
+| `src/components/DiaryForm.tsx` | 创建 | 新增日记表单主组件 |
+| `src/components/DiaryDetail.tsx` | 创建 | 极简详情页展示组件 |
+| `src/app/diary/new/page.tsx` | 创建 | 新增日记页面 |
+| `src/app/diary/[id]/page.tsx` | 创建 | 极简详情页 |
+
+---
+
+## Task 1: 测试基础设施
+
+**Files:**
+- Modify: `jest.config.ts`
+- Modify: `src/lib/test-setup.ts`
+- Modify: `package.json` (scripts)
+
+**目标:** 安装组件测试依赖，更新 Jest 配置支持 `.test.tsx` 与 `jsdom` 环境。
+
+- [ ] **Step 1: 安装依赖**
+
+```bash
+pnpm add -D @testing-library/react @testing-library/jest-dom jest-environment-jsdom
+```
+
+Expected: 安装成功，无报错。
+
+- [ ] **Step 2: 修改 `jest.config.ts`**
+
+```ts
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/src/lib/test-setup.ts'],
+  testMatch: ['**/__tests__/**/*.test.ts?(x)'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+};
+
+export default config;
+```
+
+- [ ] **Step 3: 修改 `src/lib/test-setup.ts`**
+
+```ts
+import '@testing-library/jest-dom';
+import { prisma } from './prisma';
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+```
+
+- [ ] **Step 4: 运行现有测试确保无回归**
+
+```bash
+pnpm test
+```
+
+Expected: 所有现有测试通过（约 20 个）。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add jest.config.ts src/lib/test-setup.ts package.json pnpm-lock.yaml
+git commit -m "chore(test): 安装 React Testing Library，支持 .test.tsx 与 jsdom"
+```
+
+---
+
+## Task 2: useDiaryDraft hook (TDD)
+
+**Files:**
+- Create: `src/hooks/useDiaryDraft.ts`
+- Create: `src/hooks/__tests__/useDiaryDraft.test.ts`
+
+**目标:** 实现草稿自动保存 hook，500ms 防抖，支持初始化恢复与清除。
+
+- [ ] **Step 1: 创建目录并写 failing test**
+
+```bash
+mkdir -p src/hooks/__tests__
+```
+
+创建 `src/hooks/__tests__/useDiaryDraft.test.ts`:
+
+```ts
+import { renderHook, act } from '@testing-library/react';
+import { useDiaryDraft } from '../useDiaryDraft';
+
+describe('useDiaryDraft', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('初始化返回默认值', () => {
+    const { result } = renderHook(() =>
+      useDiaryDraft('diary-draft', { content: '' }),
+    );
+    expect(result.current[0]).toEqual({ content: '' });
+  });
+
+  test('500ms 防抖后保存到 localStorage', () => {
+    jest.useFakeTimers();
+    const { result } = renderHook(() =>
+      useDiaryDraft('diary-draft', { content: '' }),
+    );
+
+    act(() => {
+      result.current[1]({ content: 'hello' });
+    });
+
+    expect(localStorage.getItem('diary-draft')).toBeNull();
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(localStorage.getItem('diary-draft')).toBe(
+      JSON.stringify({ content: 'hello' }),
+    );
+    jest.useRealTimers();
+  });
+
+  test('挂载时恢复 localStorage 草稿', () => {
+    localStorage.setItem('diary-draft', JSON.stringify({ content: 'restored' }));
+
+    const { result } = renderHook(() =>
+      useDiaryDraft('diary-draft', { content: '' }),
+    );
+
+    expect(result.current[0]).toEqual({ content: 'restored' });
+  });
+
+  test('clearDraft 清除 localStorage', () => {
+    localStorage.setItem('diary-draft', JSON.stringify({ content: 'hello' }));
+
+    const { result } = renderHook(() =>
+      useDiaryDraft('diary-draft', { content: '' }),
+    );
+
+    act(() => {
+      result.current[2]();
+    });
+
+    expect(localStorage.getItem('diary-draft')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: 运行 test 确认失败**
+
+```bash
+pnpm test src/hooks/__tests__/useDiaryDraft.test.ts
+```
+
+Expected: FAIL — `Cannot find module '../useDiaryDraft'`。
+
+- [ ] **Step 3: 实现 hook**
+
+创建 `src/hooks/useDiaryDraft.ts`:
+
+```ts
+'use client';
+
+import { useState, useEffect } from 'react';
+
+export function useDiaryDraft<T>(key: string, defaultValue: T) {
+  const [draft, setDraft] = useState<T>(defaultValue);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const saved = localStorage.getItem(key);
+    if (saved) {
+      try {
+        setDraft(JSON.parse(saved));
+      } catch {
+        localStorage.removeItem(key);
+      }
+    }
+  }, [key]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const timer = setTimeout(() => {
+      localStorage.setItem(key, JSON.stringify(draft));
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [draft, key]);
+
+  const clearDraft = () => {
+    if (typeof window === 'undefined') return;
+    localStorage.removeItem(key);
+  };
+
+  return [draft, setDraft, clearDraft] as const;
+}
+```
+
+- [ ] **Step 4: 运行 test 确认通过**
+
+```bash
+pnpm test src/hooks/__tests__/useDiaryDraft.test.ts
+```
+
+Expected: 4 tests PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/
+git commit -m "feat(hooks): useDiaryDraft 草稿自动保存 hook"
+```
+
+---
+
+## Task 3: MoodSelector 组件 (TDD)
+
+**Files:**
+- Create: `src/components/MoodSelector.tsx`
+- Create: `src/components/__tests__/MoodSelector.test.tsx`
+
+**目标:** 实现心情下拉选择器，5 个选项，点击展开/收起，选中后触发 onChange。
+
+- [ ] **Step 1: 写 failing test**
+
+创建 `src/components/__tests__/MoodSelector.test.tsx`:
+
+```ts
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MoodSelector, MOODS } from '../MoodSelector';
+
+describe('MoodSelector', () => {
+  test('默认渲染当前选中项', () => {
+    render(<MoodSelector value="sweet" onChange={jest.fn()} />);
+    expect(screen.getByText('甜甜的')).toBeInTheDocument();
+  });
+
+  test('点击展开下拉面板', () => {
+    render(<MoodSelector value="sweet" onChange={jest.fn()} />);
+    fireEvent.click(screen.getByRole('button'));
+    MOODS.forEach((mood) => {
+      expect(screen.getByText(mood.label)).toBeInTheDocument();
+    });
+  });
+
+  test('选择选项后触发 onChange 并关闭面板', () => {
+    const onChange = jest.fn();
+    render(<MoodSelector value="sweet" onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole('button'));
+    fireEvent.click(screen.getByText('开心'));
+
+    expect(onChange).toHaveBeenCalledWith('happy');
+    expect(screen.queryByText('想念')).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: 运行 test 确认失败**
+
+```bash
+pnpm test src/components/__tests__/MoodSelector.test.tsx
+```
+
+Expected: FAIL — `Cannot find module '../MoodSelector'`。
+
+- [ ] **Step 3: 实现组件**
+
+创建 `src/components/MoodSelector.tsx`:
+
+```ts
+'use client';
+
+import { useState } from 'react';
+
+export const MOODS = [
+  { value: 'sweet', label: '甜甜的', color: '#F7C8D0' },
+  { value: 'happy', label: '开心', color: '#B8DDA8' },
+  { value: 'miss', label: '想念', color: '#AFC9F7' },
+  { value: 'calm', label: '平静', color: '#D8C7E8' },
+  { value: 'sad', label: '小难过', color: '#E8C4A0' },
+] as const;
+
+export type MoodValue = (typeof MOODS)[number]['value'];
+
+interface MoodSelectorProps {
+  value: MoodValue;
+  onChange: (value: MoodValue) => void;
+}
+
+export function MoodSelector({ value, onChange }: MoodSelectorProps) {
+  const [open, setOpen] = useState(false);
+  const selected = MOODS.find((m) => m.value === value) ?? MOODS[0];
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="flex items-center gap-2 px-3 py-2 rounded-lg border border-border-soft bg-card"
+        aria-expanded={open}
+      >
+        <span
+          className="w-3 h-3 rounded-full"
+          style={{ backgroundColor: selected.color }}
+        />
+        <span className="text-sm text-text-main">{selected.label}</span>
+      </button>
+
+      {open && (
+        <div className="absolute z-10 mt-1 w-full min-w-[120px] rounded-lg border border-border-soft bg-card shadow-lg overflow-hidden">
+          {MOODS.map((mood) => (
+            <button
+              key={mood.value}
+              type="button"
+              onClick={() => {
+                onChange(mood.value);
+                setOpen(false);
+              }}
+              className="flex items-center gap-2 w-full px-3 py-2 hover:bg-cream text-left"
+            >
+              <span
+                className="w-3 h-3 rounded-full"
+                style={{ backgroundColor: mood.color }}
+              />
+              <span className="text-sm text-text-main">{mood.label}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: 运行 test 确认通过**
+
+```bash
+pnpm test src/components/__tests__/MoodSelector.test.tsx
+```
+
+Expected: 3 tests PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/MoodSelector.tsx src/components/__tests__/MoodSelector.test.tsx
+git commit -m "feat(components): MoodSelector 心情下拉选择器"
+```
+
+---
+
+## Task 4: ImageUrlInput 组件 (TDD)
+
+**Files:**
+- Create: `src/components/ImageUrlInput.tsx`
+- Create: `src/components/__tests__/ImageUrlInput.test.tsx`
+
+**目标:** 实现图片 URL 动态列表，支持添加（格式校验）与删除。
+
+- [ ] **Step 1: 写 failing test**
+
+创建 `src/components/__tests__/ImageUrlInput.test.tsx`:
+
+```ts
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ImageUrlInput } from '../ImageUrlInput';
+
+describe('ImageUrlInput', () => {
+  test('添加有效 URL', () => {
+    const onChange = jest.fn();
+    render(<ImageUrlInput urls={[]} onChange={onChange} />);
+
+    fireEvent.change(screen.getByPlaceholderText('粘贴图片链接'), {
+      target: { value: 'https://example.com/photo.jpg' },
+    });
+    fireEvent.click(screen.getByText('添加'));
+
+    expect(onChange).toHaveBeenCalledWith(['https://example.com/photo.jpg']);
+  });
+
+  test('拒绝无效 URL', () => {
+    const onChange = jest.fn();
+    render(<ImageUrlInput urls={[]} onChange={onChange} />);
+
+    fireEvent.change(screen.getByPlaceholderText('粘贴图片链接'), {
+      target: { value: 'not-a-url' },
+    });
+    fireEvent.click(screen.getByText('添加'));
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByText('请输入有效的图片地址')).toBeInTheDocument();
+  });
+
+  test('删除 URL', () => {
+    const onChange = jest.fn();
+    render(
+      <ImageUrlInput
+        urls={['https://example.com/1.jpg', 'https://example.com/2.jpg']}
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.click(screen.getAllByText('删除')[0]);
+
+    expect(onChange).toHaveBeenCalledWith(['https://example.com/2.jpg']);
+  });
+});
+```
+
+- [ ] **Step 2: 运行 test 确认失败**
+
+```bash
+pnpm test src/components/__tests__/ImageUrlInput.test.tsx
+```
+
+Expected: FAIL — `Cannot find module '../ImageUrlInput'`。
+
+- [ ] **Step 3: 实现组件**
+
+创建 `src/components/ImageUrlInput.tsx`:
+
+```ts
+'use client';
+
+import { useState } from 'react';
+
+interface ImageUrlInputProps {
+  urls: string[];
+  onChange: (urls: string[]) => void;
+}
+
+export function ImageUrlInput({ urls, onChange }: ImageUrlInputProps) {
+  const [input, setInput] = useState('');
+  const [error, setError] = useState('');
+
+  const addUrl = () => {
+    const trimmed = input.trim();
+    if (!trimmed) return;
+    try {
+      new URL(trimmed);
+      onChange([...urls, trimmed]);
+      setInput('');
+      setError('');
+    } catch {
+      setError('请输入有效的图片地址');
+    }
+  };
+
+  const removeUrl = (index: number) => {
+    onChange(urls.filter((_, i) => i !== index));
+  };
+
+  return (
+    <div className="space-y-2">
+      {urls.map((url, index) => (
+        <div key={`${url}-${index}`} className="flex items-center gap-2">
+          <span className="flex-1 text-sm text-text-sub truncate">{url}</span>
+          <button
+            type="button"
+            onClick={() => removeUrl(index)}
+            className="text-sm text-accent hover:text-text-main"
+          >
+            删除
+          </button>
+        </div>
+      ))}
+
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => {
+            setInput(e.target.value);
+            if (error) setError('');
+          }}
+          placeholder="粘贴图片链接"
+          className="flex-1 px-3 py-2 rounded-lg border border-border-soft bg-card text-sm"
+        />
+        <button
+          type="button"
+          onClick={addUrl}
+          className="px-3 py-2 rounded-lg bg-primary text-white text-sm font-medium"
+        >
+          添加
+        </button>
+      </div>
+      {error && <p className="text-sm text-red-500">{error}</p>}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: 运行 test 确认通过**
+
+```bash
+pnpm test src/components/__tests__/ImageUrlInput.test.tsx
+```
+
+Expected: 3 tests PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/ImageUrlInput.tsx src/components/__tests__/ImageUrlInput.test.tsx
+git commit -m "feat(components): ImageUrlInput 外链图片 URL 输入"
+```
+
+---
+
+## Task 5: 表单校验逻辑 (TDD)
+
+**Files:**
+- Create: `src/components/DiaryForm.validation.ts`
+- Create: `src/components/__tests__/DiaryForm.validation.test.ts`
+
+**目标:** 提取表单校验为纯函数，覆盖正文非空、长度边界。
+
+- [ ] **Step 1: 写 failing test**
+
+创建 `src/components/__tests__/DiaryForm.validation.test.ts`:
+
+```ts
+import { validateDiaryForm } from '../DiaryForm.validation';
+
+describe('validateDiaryForm', () => {
+  const base = {
+    date: '2025-01-15',
+    title: '',
+    content: '今天很开心',
+    mood: 'sweet' as const,
+    images: [] as string[],
+  };
+
+  test('空正文返回错误', () => {
+    const result = validateDiaryForm({ ...base, content: '' });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('写点什么吧');
+  });
+
+  test('空白正文返回错误', () => {
+    const result = validateDiaryForm({ ...base, content: '   ' });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('写点什么吧');
+  });
+
+  test('10000 字符正文通过', () => {
+    const result = validateDiaryForm({ ...base, content: 'a'.repeat(10000) });
+    expect(result.ok).toBe(true);
+  });
+
+  test('10001 字符正文失败', () => {
+    const result = validateDiaryForm({ ...base, content: 'a'.repeat(10001) });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('正文太长了，最多 10000 字');
+  });
+});
+```
+
+- [ ] **Step 2: 运行 test 确认失败**
+
+```bash
+pnpm test src/components/__tests__/DiaryForm.validation.test.ts
+```
+
+Expected: FAIL — `Cannot find module '../DiaryForm.validation'`。
+
+- [ ] **Step 3: 实现校验函数**
+
+创建 `src/components/DiaryForm.validation.ts`:
+
+```ts
+export interface DiaryFormData {
+  date: string;
+  title: string;
+  content: string;
+  mood: string;
+  images: string[];
+}
+
+export function validateDiaryForm(
+  data: DiaryFormData,
+): { ok: boolean; error?: string } {
+  if (!data.content.trim()) {
+    return { ok: false, error: '写点什么吧' };
+  }
+  if (data.content.length > 10000) {
+    return { ok: false, error: '正文太长了，最多 10000 字' };
+  }
+  return { ok: true };
+}
+```
+
+- [ ] **Step 4: 运行 test 确认通过**
+
+```bash
+pnpm test src/components/__tests__/DiaryForm.validation.test.ts
+```
+
+Expected: 4 tests PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/DiaryForm.validation.ts src/components/__tests__/DiaryForm.validation.test.ts
+git commit -m "feat(validation): 日记表单校验逻辑"
+```
+
+---
+
+## Task 6: DiaryForm 主组件
+
+**Files:**
+- Create: `src/components/DiaryForm.tsx`
+
+**目标:** 组装表单主组件，集成 hook、子组件、校验、Server Action 调用与跳转。
+
+- [ ] **Step 1: 实现 DiaryForm 组件**
+
+创建 `src/components/DiaryForm.tsx`:
+
+```ts
+'use client';
+
+import { useState, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import dayjs from 'dayjs';
+import { createDiary } from '@/lib/actions';
+import { useDiaryDraft } from '@/hooks/useDiaryDraft';
+import { MoodSelector, type MoodValue } from './MoodSelector';
+import { ImageUrlInput } from './ImageUrlInput';
+import { validateDiaryForm } from './DiaryForm.validation';
+
+export interface DiaryFormData {
+  date: string;
+  title: string;
+  content: string;
+  mood: MoodValue;
+  images: string[];
+}
+
+const defaultForm: DiaryFormData = {
+  date: dayjs().format('YYYY-MM-DD'),
+  title: '',
+  content: '',
+  mood: 'sweet',
+  images: [],
+};
+
+export function DiaryForm() {
+  const router = useRouter();
+  const [form, setForm, clearDraft] = useDiaryDraft<DiaryFormData>(
+    'diary-draft',
+    defaultForm,
+  );
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState(false);
+
+  const updateField = useCallback(
+    <K extends keyof DiaryFormData>(key: K, value: DiaryFormData[K]) => {
+      setForm((prev) => ({ ...prev, [key]: value }));
+    },
+    [setForm],
+  );
+
+  const handleSubmit = async () => {
+    setError('');
+    setSuccess(false);
+
+    const validation = validateDiaryForm(form);
+    if (!validation.ok) {
+      setError(validation.error!);
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const entry = await createDiary({
+        date: new Date(form.date),
+        title: form.title || undefined,
+        content: form.content,
+        mood: form.mood,
+        images: form.images.length > 0 ? form.images : undefined,
+      });
+      clearDraft();
+      setSuccess(true);
+      setTimeout(() => {
+        router.push(`/diary/${entry.id}`);
+      }, 1500);
+    } catch {
+      setError('保存失败，请稍后重试');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      {success && (
+        <div className="px-4 py-3 rounded-lg bg-primary/20 text-text-main text-sm text-center">
+          今天的心情已经收藏好了
+        </div>
+      )}
+      {error && (
+        <div className="px-4 py-3 rounded-lg bg-red-50 text-red-600 text-sm text-center">
+          {error}
+        </div>
+      )}
+
+      <div className="flex flex-col sm:flex-row gap-4">
+        <input
+          type="date"
+          value={form.date}
+          onChange={(e) => updateField('date', e.target.value)}
+          className="px-3 py-2 rounded-lg border border-border-soft bg-card text-sm text-text-main"
+        />
+        <MoodSelector
+          value={form.mood}
+          onChange={(v) => updateField('mood', v)}
+        />
+      </div>
+
+      <input
+        type="text"
+        value={form.title}
+        onChange={(e) => updateField('title', e.target.value)}
+        placeholder="给今天起个名字（可选）"
+        className="w-full px-3 py-2 rounded-lg border border-border-soft bg-card text-sm text-text-main"
+      />
+
+      <div className="relative">
+        <textarea
+          value={form.content}
+          onChange={(e) => updateField('content', e.target.value)}
+          placeholder="今天发生了什么？"
+          rows={8}
+          className="w-full px-3 py-2 rounded-lg border border-border-soft bg-card text-sm text-text-main resize-none"
+          style={{ fontSize: '16px' }}
+        />
+        <span
+          className={`absolute bottom-2 right-2 text-xs ${
+            form.content.length > 10000 ? 'text-red-500' : 'text-text-sub'
+          }`}
+        >
+          {form.content.length}/10000
+        </span>
+      </div>
+
+      <div className="space-y-1">
+        <label className="text-sm text-text-sub">图片</label>
+        <ImageUrlInput
+          urls={form.images}
+          onChange={(v) => updateField('images', v)}
+        />
+      </div>
+
+      <button
+        onClick={handleSubmit}
+        disabled={saving}
+        className="w-full py-3 rounded-lg bg-primary text-white font-medium disabled:opacity-50 mt-4"
+      >
+        {saving ? '保存中...' : '保存'}
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: 运行全部测试确认无回归**
+
+```bash
+pnpm test
+```
+
+Expected: 所有测试通过（约 34 个）。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/DiaryForm.tsx
+git commit -m "feat(components): DiaryForm 新增日记表单主组件"
+```
+
+---
+
+## Task 7: 新增日记页面 `/diary/new`
+
+**Files:**
+- Create: `src/app/diary/new/page.tsx`
+
+**目标:** 创建新增日记页面，引入 DiaryForm 并添加页面级布局。
+
+- [ ] **Step 1: 创建目录与页面**
+
+```bash
+mkdir -p src/app/diary/new
+```
+
+创建 `src/app/diary/new/page.tsx`:
+
+```ts
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { DiaryForm } from '@/components/DiaryForm';
+
+export const metadata: Metadata = {
+  title: '写下今天',
+};
+
+export default function NewDiaryPage() {
+  return (
+    <main className="min-h-screen bg-cream">
+      <div className="max-w-[480px] mx-auto px-4 py-6">
+        <div className="flex items-center gap-4 mb-6">
+          <Link
+            href="/"
+            className="text-text-sub hover:text-text-main transition-colors"
+            aria-label="返回"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="m15 18-6-6 6-6" />
+            </svg>
+          </Link>
+          <h1 className="text-lg font-bold text-text-main">写下今天</h1>
+        </div>
+        <DiaryForm />
+      </div>
+    </main>
+  );
+}
+```
+
+- [ ] **Step 2: Dev server 验证**
+
+```bash
+pnpm dev
+```
+
+在浏览器访问 `http://localhost:3000/diary/new`，验证：
+- 页面正常渲染，无报错
+- 表单字段齐全（日期、心情、标题、正文、图片、保存按钮）
+- 心情选择器可点击展开
+- 正文输入后 500ms 刷新页面，草稿恢复
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/diary/new/page.tsx
+git commit -m "feat(page): /diary/new 新增日记页面"
+```
+
+---
+
+## Task 8: 极简详情页组件与路由
+
+**Files:**
+- Create: `src/components/DiaryDetail.tsx`
+- Create: `src/app/diary/[id]/page.tsx`
+
+**目标:** 实现极简详情页展示组件与对应路由。
+
+- [ ] **Step 1: 实现 DiaryDetail 组件**
+
+创建 `src/components/DiaryDetail.tsx`:
+
+```ts
+import dayjs from 'dayjs';
+import type { DiaryEntry, DiaryImage } from '@prisma/client';
+
+interface DiaryDetailProps {
+  entry: DiaryEntry & { images: DiaryImage[] };
+}
+
+const moodMap: Record<string, { label: string; color: string }> = {
+  sweet: { label: '甜甜的', color: '#F7C8D0' },
+  happy: { label: '开心', color: '#B8DDA8' },
+  miss: { label: '想念', color: '#AFC9F7' },
+  calm: { label: '平静', color: '#D8C7E8' },
+  sad: { label: '小难过', color: '#E8C4A0' },
+};
+
+export function DiaryDetail({ entry }: DiaryDetailProps) {
+  const displayTitle =
+    entry.title || `${dayjs(entry.date).format('YYYY年M月D日')} 的心情`;
+  const mood = moodMap[entry.mood] || moodMap.sweet;
+
+  return (
+    <article className="space-y-4">
+      <h1 className="text-xl font-bold text-text-main">{displayTitle}</h1>
+
+      <div className="flex items-center gap-2 text-sm text-text-sub">
+        <span>{dayjs(entry.date).format('YYYY年M月D日')}</span>
+        <span
+          className="flex items-center gap-1 px-2 py-0.5 rounded-full"
+          style={{ backgroundColor: mood.color + '33' }}
+        >
+          <span
+            className="w-2 h-2 rounded-full"
+            style={{ backgroundColor: mood.color }}
+          />
+          {mood.label}
+        </span>
+      </div>
+
+      <p className="text-base text-text-main whitespace-pre-wrap leading-relaxed">
+        {entry.content}
+      </p>
+
+      {entry.images.length > 0 && (
+        <div
+          className={`grid gap-2 ${
+            entry.images.length === 1 ? 'grid-cols-1' : 'grid-cols-2'
+          }`}
+        >
+          {entry.images.map((img) => (
+            <img
+              key={img.id}
+              src={img.url}
+              alt=""
+              className="w-full rounded-lg object-cover"
+              loading="lazy"
+            />
+          ))}
+        </div>
+      )}
+    </article>
+  );
+}
+```
+
+- [ ] **Step 2: 实现详情页路由**
+
+```bash
+mkdir -p src/app/diary/\[id\]
+```
+
+创建 `src/app/diary/[id]/page.tsx`:
+
+```ts
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { getDiaryById } from '@/lib/actions';
+import { DiaryDetail } from '@/components/DiaryDetail';
+
+interface DiaryDetailPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: DiaryDetailPageProps): Promise<Metadata> {
+  const { id } = await params;
+  const entry = await getDiaryById(id);
+  return {
+    title: entry?.title || '日记详情',
+  };
+}
+
+export default async function DiaryDetailPage({
+  params,
+}: DiaryDetailPageProps) {
+  const { id } = await params;
+  const entry = await getDiaryById(id);
+
+  if (!entry) {
+    notFound();
+  }
+
+  return (
+    <main className="min-h-screen bg-cream">
+      <div className="max-w-[480px] mx-auto px-4 py-6">
+        <div className="flex items-center gap-4 mb-6">
+          <Link
+            href="/diary/new"
+            className="text-text-sub hover:text-text-main transition-colors"
+            aria-label="返回"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="m15 18-6-6 6-6" />
+            </svg>
+          </Link>
+          <h1 className="text-lg font-bold text-text-main">日记详情</h1>
+        </div>
+        <div className="bg-card rounded-2xl p-4 shadow-sm">
+          <DiaryDetail entry={entry} />
+        </div>
+      </div>
+    </main>
+  );
+}
+```
+
+- [ ] **Step 3: Dev server 验证详情页**
+
+确保 dev server 仍在运行（`pnpm dev`），在 `/diary/new` 页面填写内容并保存，观察是否：
+- 显示成功提示"今天的心情已经收藏好了"
+- 1.5 秒后跳转到 `/diary/[id]`
+- 详情页正确显示标题、日期、心情、正文、图片
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/DiaryDetail.tsx src/app/diary/\[id\]/page.tsx
+git commit -m "feat(page): /diary/[id] 极简详情页占位"
+```
+
+---
+
+## Task 9: 端到端验证
+
+**Files:**
+- 全部已有文件
+
+**目标:** 运行全部校验，确保无回归、无类型错误、构建通过。
+
+- [ ] **Step 1: 运行全部测试**
+
+```bash
+pnpm test
+```
+
+Expected: 所有测试通过。
+
+- [ ] **Step 2: 运行 ESLint**
+
+```bash
+pnpm lint
+```
+
+Expected: 无 error，无 warn（或仅存在项目已有的 warn）。
+
+- [ ] **Step 3: 运行生产构建**
+
+```bash
+pnpm build
+```
+
+Expected: 构建成功，无类型错误，路由 `/diary/new` 与 `/diary/[id]` 均被编译。
+
+- [ ] **Step 4: 边界情况手工验证**
+
+在 dev server 中验证以下场景：
+
+- [ ] 正文为空时点击保存，显示"写点什么吧"
+- [ ] 正文输入 10001 字符，字符计数变红，保存按钮点击后显示错误
+- [ ] 添加无效图片 URL（如"abc"），显示"请输入有效的图片地址"
+- [ ] 添加 2 个有效图片 URL，保存后在详情页显示 2 列网格
+- [ ] 标题为空时保存，详情页显示"YYYY年M月D日 的心情"
+- [ ] 快速连续点击保存按钮，只有第一次触发请求
+- [ ] 输入过程中刷新页面，草稿自动恢复
+- [ ] 保存成功后刷新 `/diary/new`，表单回到默认空状态（草稿已清除）
+
+- [ ] **Step 5: Commit（如有 lint/build 修复）**
+
+```bash
+git add -A
+git commit -m "fix: 边界情况处理与 lint/build 修复" || echo "no changes to commit"
+```
+
+---
+
+## Self-Review Checklist
+
+### 1. Spec Coverage
+
+| Spec 要求 | 对应 Task |
+|-----------|-----------|
+| 日期选择器默认今天 | Task 6 (defaultForm.date) |
+| 标题为空允许提交 | Task 6 (title: form.title \|\| undefined) |
+| 心情 5 选项默认"甜甜的" | Task 3 (MOODS, defaultForm.mood) |
+| 正文空阻止提交 | Task 5 (validateDiaryForm) |
+| 正文 max 10000 | Task 5 + Task 6 (字符计数 + 校验) |
+| 多张外链图片 URL | Task 4 (ImageUrlInput) |
+| 删除图片 URL | Task 4 |
+| localStorage 草稿 500ms 防抖 | Task 2 (useDiaryDraft) |
+| 刷新后草稿恢复 | Task 2 + Task 6 |
+| 保存成功跳转 `/diary/[id]` | Task 6 (router.push) + Task 8 |
+| 顶部成功提示 | Task 6 (success state) |
+| 极简详情页 | Task 8 |
+| animal-island-ui 组件 | 暂不强制使用（Issue 未指定具体组件，且表单字段简单） |
+| 输入框聚焦边框 #ffcc00 | Task 6 (globals.css 已有 focus 样式或需补充) |
+| 移动端字号 ≥16px | Task 6 (textarea style fontSize: '16px') |
+| prefers-reduced-motion | 下拉面板无动画，天然支持 |
+
+**Gap:** animal-island-ui 的 `Input`、`Button` 组件未在计划中使用。若项目要求必须使用，需在 Task 6 中替换为 `import { Input, Button } from 'animal-island-ui'`。当前计划使用原生 `input`/`textarea`/`button` + Tailwind 样式，更轻量且与现有 SettingsForm 风格一致。
+
+### 2. Placeholder Scan
+
+- 无 "TBD" / "TODO" / "implement later" / "fill in details"
+- 无 "Add appropriate error handling" 等模糊描述
+- 每个 Task 的代码均为完整可运行代码
+
+### 3. Type Consistency
+
+- `MoodValue` 在 Task 3 定义，Task 6 的 `DiaryFormData` 和 `defaultForm` 中使用 — 一致
+- `DiaryFormData` 在 Task 5 和 Task 6 中定义一致
+- `createDiary` 参数类型来自已有 `CreateDiaryInput`，与表单字段映射正确
+- `getDiaryById` 返回类型 `DiaryEntry & { images: DiaryImage[] }` 与 `DiaryDetail` props 一致

--- a/docs/superpowers/specs/2026-05-03-diary-new-page-design.md
+++ b/docs/superpowers/specs/2026-05-03-diary-new-page-design.md
@@ -1,0 +1,202 @@
+# 新增日记页 + 极简详情页 — 设计文档
+
+## 来源
+
+- Issue #6: `[M2] 新增日记页：表单 + 心情选择器 + 外链图片 + 草稿自动保存`
+- 设计决策会议：2026-05-03
+
+## 背景与目标
+
+写日记是产品的核心功能。第一版需要支持日期、标题、心情、正文和外链图片 URL。表单设计要简洁低负担，减少用户记录时的心理压力。
+
+## 关键决策
+
+1. **同时实现极简详情页占位**：Issue #7（单篇日记页）尚未开发，在 Issue #6 中同步实现一个极简 `/diary/[id]` 页面，确保保存后有地方跳转。
+2. **心情选择器采用下拉形式**：新增页是后台记录场景，简洁高效优先，不追求趣味性。
+3. **实现方案采用轻量受控组件**：使用 `useState` + 自定义 `useDiaryDraft` hook，不引入 `react-hook-form` 或 `useActionState`。
+
+## 页面路由
+
+| 路由 | 用途 | 类型 |
+|------|------|------|
+| `/diary/new` | 新增日记表单 | Client Component |
+| `/diary/[id]/page.tsx` | 极简日记详情页占位 | Server Component |
+
+## 新增组件清单
+
+### `src/components/DiaryForm.tsx`
+
+新增日记表单主组件。职责：
+- 管理所有表单字段的受控状态
+- 集成 `useDiaryDraft` 实现草稿自动保存
+- 调用 `createDiary` Server Action 提交
+- 保存成功后清草稿、显示提示、跳转详情页
+- 客户端表单校验（正文非空、长度限制）
+
+### `src/components/MoodSelector.tsx`
+
+心情下拉选择器。职责：
+- 展示 5 种心情选项的下拉面板
+- 当前选中项显示色块圆点 + 文字
+- 触发器与下拉面板均为自定义样式（非原生 `<select>`）
+
+**心情数据：**
+
+```typescript
+const MOODS = [
+  { value: 'sweet', label: '甜甜的', color: '#F7C8D0' },
+  { value: 'happy', label: '开心', color: '#B8DDA8' },
+  { value: 'miss',  label: '想念',  color: '#AFC9F7' },
+  { value: 'calm',  label: '平静',  color: '#D8C7E8' },
+  { value: 'sad',   label: '小难过', color: '#E8C4A0' },
+] as const;
+```
+
+### `src/components/ImageUrlInput.tsx`
+
+图片 URL 动态列表。职责：
+- 显示已添加的 URL 列表，每项带删除按钮
+- "添加图片"按钮，点击后展开输入框 + 确认/取消
+- 前端用 `URL` 构造函数简单校验格式，无效 URL 不被添加
+
+### `src/components/DiaryDetail.tsx`
+
+极简详情页展示组件。职责：
+- 接收 `DiaryEntry` + `DiaryImage[]` 数据
+- 展示日期、心情标签、标题、正文、图片网格
+- 标题为空时显示默认格式：`${formattedDate} 的心情`
+
+### `src/hooks/useDiaryDraft.ts`
+
+草稿自动保存 hook。职责：
+- 初始化时从 `localStorage` 读取草稿
+- 数据变化后 500ms 防抖自动保存
+- 提供 `clearDraft` 方法供提交成功后调用
+
+```typescript
+function useDiaryDraft<T>(key: string, defaultValue: T) {
+  const [draft, setDraft] = useState<T>(defaultValue);
+
+  // 仅在客户端挂载后读取 localStorage，避免 SSR hydration mismatch
+  useEffect(() => {
+    const saved = localStorage.getItem(key);
+    if (saved) {
+      try {
+        setDraft(JSON.parse(saved));
+      } catch {
+        localStorage.removeItem(key);
+      }
+    }
+  }, [key]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      localStorage.setItem(key, JSON.stringify(draft));
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [draft, key]);
+
+  const clearDraft = () => localStorage.removeItem(key);
+
+  return [draft, setDraft, clearDraft] as const;
+}
+```
+
+## 表单布局设计
+
+从上到下依次为：
+
+1. **顶部栏**：左侧返回按钮，中间标题"写下今天"
+2. **日期行**：日期 `input[type="date"]`（默认今天）+ 心情选择器并排；移动端上下堆叠
+3. **标题输入**：单行文本，placeholder"给今天起个名字（可选）"
+4. **正文输入**：多行 textarea，最小 8 行高，placeholder"今天发生了什么？"
+5. **字符计数**：textarea 右下角显示 `当前长度 / 10000`，超限后文字变红
+6. **图片 URL 区域**：已添加 URL 列表（带删除）+ 添加按钮
+7. **底部保存按钮**：`position: sticky`，移动端避免被键盘遮挡
+
+## 数据流
+
+```
+用户输入 → DiaryForm (useState)
+    ↓ (防抖 500ms)
+localStorage.setItem('diary-draft', JSON.stringify(formData))
+    ↓ (用户点击保存)
+createDiary Server Action → Prisma → SQLite
+    ↓ (成功)
+localStorage.removeItem('diary-draft')
+useRouter().push(`/diary/${id}`)
+```
+
+## 表单校验规则
+
+| 规则 | 校验时机 | 处理方式 |
+|------|----------|----------|
+| 正文非空 | 提交时 | 阻止提交，显示提示"写点什么吧" |
+| 正文 ≤ 10000 字符 | 实时 + 提交时 | 超限时保存按钮禁用，字符计数变红 |
+| 图片 URL 格式 | 添加时 | 无效 URL 不加入列表 |
+| 日期必填 | 提交时 | 日期 input 默认今天，理论上不会为空 |
+
+## 错误处理
+
+- **服务端校验失败**（如 content 超 10000）：显示通用错误提示"保存失败，请检查内容"
+- **服务端异常**（数据库错误）：显示"保存失败，请稍后重试"
+- **重复提交**：保存按钮 loading 态 + 禁用
+- **草稿恢复异常**（localStorage 数据损坏）：静默回退到默认值，不阻断用户使用
+
+## 极简详情页设计
+
+**页面结构：**
+
+1. **顶部栏**：返回按钮 + 日期标题（如"2025年1月15日"）
+2. **内容卡片**：
+   - 标题（空时显示 `${date} 的心情`）
+   - 心情标签（色块圆点 + 文字）
+   - 正文
+   - 图片网格：1 张时全宽，多张时 2 列网格
+
+**响应式：**
+
+- 移动端：图片单列
+- 桌面端：内容区 max-width 480px 居中，图片最多 2 列
+
+## 测试策略
+
+### 新增测试文件
+
+| 测试目标 | 位置 |
+|----------|------|
+| `useDiaryDraft` hook | `src/hooks/__tests__/useDiaryDraft.test.ts` |
+| `MoodSelector` 组件 | `src/components/__tests__/MoodSelector.test.tsx` |
+| `ImageUrlInput` 组件 | `src/components/__tests__/ImageUrlInput.test.tsx` |
+| 表单校验逻辑 | `src/components/__tests__/DiaryForm.validation.test.tsx` |
+
+### 已有测试沿用
+
+`src/lib/__tests__/actions.test.ts` 中 `createDiary` 相关测试已覆盖服务端校验和数据库写入，无需修改。
+
+### 边界情况自测清单
+
+- [ ] 正文刚好 10000 字符允许提交
+- [ ] 正文 10001 字符客户端阻止、服务端也拒绝
+- [ ] 快速连续点击保存按钮（按钮 loading 态防重）
+- [ ] 刷新页面后草稿自动恢复
+- [ ] 标题为空提交后，详情页显示默认标题
+- [ ] 添加无效 URL（如"not-a-url"）不被接受
+- [ ] 保存成功后 localStorage 草稿被清除
+- [ ] `prefers-reduced-motion` 下无动画
+
+## 不包含范围
+
+- 天气字段（P2）
+- 标签系统（P2）
+- 图片本地上传（P1）
+- 富文本编辑器（纯文本即可）
+- 上一篇/下一篇翻页导航（Issue #7）
+
+## 依赖
+
+- `animal-island-ui`（Button、Input 等组件）
+- `framer-motion`（项目已有，但心情选择器本次不使用动画）
+- `dayjs`（日期格式化）
+- 已有 Server Actions：`createDiary`、`getDiaryById`
+- 已有 Schema：`CreateDiarySchema`

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -2,9 +2,13 @@ import type { Config } from 'jest';
 
 const config: Config = {
   preset: 'ts-jest',
-  testEnvironment: 'node',
+  testEnvironment: 'jsdom',
+  setupFiles: ['<rootDir>/src/lib/test-polyfill.ts'],
   setupFilesAfterEnv: ['<rootDir>/src/lib/test-setup.ts'],
-  testMatch: ['**/__tests__/**/*.test.ts'],
+  testMatch: ['**/__tests__/**/*.test.ts?(x)'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
 };
 
 export default config;

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/jest": "^30.0.0",
     "@types/node": "^20",
     "@types/react": "^19",
@@ -34,6 +36,7 @@
     "eslint": "^9",
     "eslint-config-next": "16.2.4",
     "jest": "^30.3.0",
+    "jest-environment-jsdom": "^30.3.0",
     "prisma": "^7.8.0",
     "tailwindcss": "^4",
     "ts-jest": "^29.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,12 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.2.4
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0
@@ -63,6 +69,9 @@ importers:
       jest:
         specifier: ^30.3.0
         version: 30.3.0(@types/node@20.19.39)
+      jest-environment-jsdom:
+        specifier: ^30.3.0
+        version: 30.3.0
       prisma:
         specifier: ^7.8.0
         version: 7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
@@ -78,9 +87,15 @@ importers:
 
 packages:
 
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -232,6 +247,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
@@ -246,6 +265,34 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@electric-sql/pglite-socket@0.1.1':
     resolution: {integrity: sha512-p2hoXw3Z3LQHwTeikdZNsFBOvXGqKY2hk51BBw+8NKND8eoH+8LFOtW9Z8CQKmTJ2qqGYu82ipqiyFZOTTXNfw==}
@@ -524,6 +571,16 @@ packages:
   '@jest/diff-sequences@30.3.0':
     resolution: {integrity: sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/environment-jsdom-abstract@30.3.0':
+    resolution: {integrity: sha512-0hNFs5N6We3DMCwobzI0ydhkY10sT1tZSC0AAiy+0g2Dt/qEWgrcV5BrMxPczhe41cxW4qm6X+jqZaUdpZIajA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+      jsdom: '*'
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   '@jest/environment@30.3.0':
     resolution: {integrity: sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==}
@@ -941,8 +998,34 @@ packages:
   '@tailwindcss/postcss@4.2.4':
     resolution: {integrity: sha512-wgAVj6nUWAolAu8YFvzT2cTBIElWHkjZwFYovF+xsqKsW2ADxM/X2opxj5NsF/qVccAOjRNe8X2IdPzMsWyHTg==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -971,6 +1054,9 @@ packages:
   '@types/jest@30.0.0':
     resolution: {integrity: sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==}
 
+  '@types/jsdom@21.1.7':
+    resolution: {integrity: sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -990,6 +1076,9 @@ packages:
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -1172,6 +1261,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
@@ -1217,6 +1310,9 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -1460,11 +1556,22 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -1497,6 +1604,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
@@ -1540,6 +1650,10 @@ packages:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
     engines: {node: '>=0.10'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
@@ -1554,6 +1668,12 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
@@ -1592,6 +1712,10 @@ packages:
   enhanced-resolve@5.21.0:
     resolution: {integrity: sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==}
     engines: {node: '>=10.13.0'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
 
   env-paths@3.0.0:
     resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
@@ -2024,15 +2148,31 @@ packages:
     resolution: {integrity: sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==}
     engines: {node: '>=16.9.0'}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
 
   http-status-codes@2.3.0:
     resolution: {integrity: sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==}
 
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -2061,6 +2201,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -2153,6 +2297,9 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
   is-property@1.0.2:
     resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
@@ -2275,6 +2422,15 @@ packages:
     resolution: {integrity: sha512-V8eMndg/aZ+3LnCJgSm13IxS5XSBM22QSZc9BtPK8Dek6pm+hfUNfwBdvsB3d342bo1q7wnSkC38zjX259qZNA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  jest-environment-jsdom@30.3.0:
+    resolution: {integrity: sha512-RLEOJy6ip1lpw0yqJ8tB3i88FC7VBz7i00Zvl2qF71IdxjS98gC9/0SPWYIBVXHm5hgCYK0PAlSlnHGGy9RoMg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
   jest-environment-node@30.3.0:
     resolution: {integrity: sha512-4i6HItw/JSiJVsC5q0hnKIe/hbYfZLVG9YJ/0pU9Hz2n/9qZe3Rhn5s5CUZA5ORZlcdT/vmAXRMyONXJwPrmYQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -2372,6 +2528,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@26.1.0:
+    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -2532,6 +2697,10 @@ packages:
     resolution: {integrity: sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==}
     engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -2567,6 +2736,10 @@ packages:
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -2668,6 +2841,9 @@ packages:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
 
+  nwsapi@2.2.23:
+    resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -2749,6 +2925,9 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -2822,6 +3001,10 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   pretty-format@30.3.0:
     resolution: {integrity: sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -2876,6 +3059,9 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
@@ -2890,6 +3076,10 @@ packages:
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -2938,6 +3128,9 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -2958,6 +3151,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -3121,6 +3318,10 @@ packages:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
@@ -3154,6 +3355,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   synckit@0.11.12:
     resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -3180,12 +3384,27 @@ packages:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -3312,8 +3531,29 @@ packages:
       typescript:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -3358,6 +3598,25 @@ packages:
     resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -3391,7 +3650,17 @@ packages:
 
 snapshots:
 
+  '@adobe/css-tools@4.4.4': {}
+
   '@alloc/quick-lru@5.2.0': {}
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -3557,6 +3826,8 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/runtime@7.29.2': {}
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -3581,6 +3852,26 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@0.2.3': {}
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@electric-sql/pglite-socket@0.1.1(@electric-sql/pglite@0.4.1)':
     dependencies:
@@ -3841,6 +4132,17 @@ snapshots:
       - ts-node
 
   '@jest/diff-sequences@30.3.0': {}
+
+  '@jest/environment-jsdom-abstract@30.3.0(jsdom@26.1.0)':
+    dependencies:
+      '@jest/environment': 30.3.0
+      '@jest/fake-timers': 30.3.0
+      '@jest/types': 30.3.0
+      '@types/jsdom': 21.1.7
+      '@types/node': 20.19.39
+      jest-mock: 30.3.0
+      jest-util: 30.3.0
+      jsdom: 26.1.0
 
   '@jest/environment@30.3.0':
     dependencies:
@@ -4288,10 +4590,42 @@ snapshots:
       postcss: 8.5.13
       tailwindcss: 4.2.4
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -4331,6 +4665,12 @@ snapshots:
       expect: 30.3.0
       pretty-format: 30.3.0
 
+  '@types/jsdom@21.1.7':
+    dependencies:
+      '@types/node': 20.19.39
+      '@types/tough-cookie': 4.0.5
+      parse5: 7.3.0
+
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
@@ -4348,6 +4688,8 @@ snapshots:
       csstype: 3.2.3
 
   '@types/stack-utils@2.0.3': {}
+
+  '@types/tough-cookie@4.0.5': {}
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -4513,6 +4855,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -4562,6 +4906,10 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -4856,9 +5204,21 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css.escape@1.5.1: {}
+
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
   csstype@3.2.3: {}
 
   damerau-levenshtein@1.0.8: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -4887,6 +5247,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decompress-response@6.0.0:
     dependencies:
@@ -4918,6 +5280,8 @@ snapshots:
 
   denque@2.1.0: {}
 
+  dequal@2.0.3: {}
+
   destr@2.0.5: {}
 
   detect-libc@2.1.2: {}
@@ -4927,6 +5291,10 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dotenv@17.4.2: {}
 
@@ -4961,6 +5329,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
+
+  entities@6.0.1: {}
 
   env-paths@3.0.0: {}
 
@@ -5536,11 +5906,33 @@ snapshots:
 
   hono@4.12.16: {}
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-escaper@2.0.2: {}
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   http-status-codes@2.3.0: {}
 
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   human-signals@2.1.0: {}
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   iconv-lite@0.7.2:
     dependencies:
@@ -5563,6 +5955,8 @@ snapshots:
       resolve-cwd: 3.0.0
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   inflight@1.0.6:
     dependencies:
@@ -5657,6 +6051,8 @@ snapshots:
       has-tostringtag: 1.0.2
 
   is-number@7.0.0: {}
+
+  is-potential-custom-element-name@1.0.1: {}
 
   is-property@1.0.2: {}
 
@@ -5851,6 +6247,16 @@ snapshots:
       chalk: 4.1.2
       jest-util: 30.3.0
       pretty-format: 30.3.0
+
+  jest-environment-jsdom@30.3.0:
+    dependencies:
+      '@jest/environment': 30.3.0
+      '@jest/environment-jsdom-abstract': 30.3.0(jsdom@26.1.0)
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jest-environment-node@30.3.0:
     dependencies:
@@ -6074,6 +6480,33 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsdom@26.1.0:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.23
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.20.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
@@ -6193,6 +6626,8 @@ snapshots:
 
   lru.min@1.1.4: {}
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -6221,6 +6656,8 @@ snapshots:
   mimic-fn@2.1.0: {}
 
   mimic-response@3.1.0: {}
+
+  min-indent@1.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -6318,6 +6755,8 @@ snapshots:
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
+
+  nwsapi@2.2.23: {}
 
   object-assign@4.1.1: {}
 
@@ -6417,6 +6856,10 @@ snapshots:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
@@ -6484,6 +6927,12 @@ snapshots:
       tunnel-agent: 0.6.0
 
   prelude-ls@1.2.1: {}
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
 
   pretty-format@30.3.0:
     dependencies:
@@ -6553,6 +7002,8 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-is@17.0.2: {}
+
   react-is@18.3.1: {}
 
   react@19.2.4: {}
@@ -6564,6 +7015,11 @@ snapshots:
       util-deprecate: 1.0.2
 
   readdirp@5.0.0: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -6614,6 +7070,8 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  rrweb-cssom@0.8.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -6640,6 +7098,10 @@ snapshots:
       is-regex: 1.2.1
 
   safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -6862,6 +7324,10 @@ snapshots:
 
   strip-final-newline@2.0.0: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
@@ -6882,6 +7348,8 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  symbol-tree@3.2.4: {}
 
   synckit@0.11.12:
     dependencies:
@@ -6917,11 +7385,25 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
   tmpl@1.0.5: {}
 
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
@@ -7074,9 +7556,26 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   walker@1.0.8:
     dependencies:
       makeerror: 1.0.12
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -7145,6 +7644,12 @@ snapshots:
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 4.1.0
+
+  ws@8.20.0: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   y18n@5.0.8: {}
 

--- a/src/app/(protected)/page.tsx
+++ b/src/app/(protected)/page.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import dayjs from 'dayjs';
-import { getCoupleProfile, getCoverStats } from '@/lib/actions';
+import { getCoupleProfile, getCoverStats, getDiaryList } from '@/lib/actions';
 import CoverLogo from '@/components/CoverLogo';
 import AnimatedDays from '@/components/AnimatedDays';
 import FloatingButton from '@/components/FloatingButton';
+import SecretWriteEntry from '@/components/SecretWriteEntry';
 
 export const dynamic = 'force-dynamic';
 
@@ -16,10 +17,13 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function Home() {
-  const [profile, stats] = await Promise.all([
+  const [profile, stats, diaries] = await Promise.all([
     getCoupleProfile(),
     getCoverStats(),
+    getDiaryList(),
   ]);
+
+  const latestDiary = diaries[0] ?? null;
 
   // layout 守卫已确保 profile 存在;保留类型收窄
   if (!profile) {
@@ -179,13 +183,17 @@ export default async function Home() {
 
         {/* 按钮 */}
         <div className="absolute bottom-32 left-1/2 -translate-x-1/2">
-          <FloatingButton href="/diary">翻开日记</FloatingButton>
+          <FloatingButton href={latestDiary ? `/diary/${latestDiary.id}` : '/diary/new'}>
+            {latestDiary ? '翻开日记' : '写下第一篇'}
+          </FloatingButton>
         </div>
 
-        {/* 统计 */}
-        <div className="absolute bottom-6 right-6 text-[10px] text-text-sub">
-          日记 {stats.diaryCount} · 回忆 {stats.memoryCount}
-        </div>
+        {/* 统计 — 连续点击3次进入写日记（隐蔽入口） */}
+        <SecretWriteEntry>
+          <div className="absolute bottom-6 right-6 text-[10px] text-text-sub">
+            日记 {stats.diaryCount} · 回忆 {stats.memoryCount}
+          </div>
+        </SecretWriteEntry>
       </div>
     </div>
   );

--- a/src/app/diary/[id]/page.tsx
+++ b/src/app/diary/[id]/page.tsx
@@ -1,0 +1,62 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { getDiaryById } from '@/lib/actions';
+import { DiaryDetail } from '@/components/DiaryDetail';
+
+interface DiaryDetailPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: DiaryDetailPageProps): Promise<Metadata> {
+  const { id } = await params;
+  const entry = await getDiaryById(id);
+  return {
+    title: entry?.title || '日记详情',
+  };
+}
+
+export default async function DiaryDetailPage({
+  params,
+}: DiaryDetailPageProps) {
+  const { id } = await params;
+  const entry = await getDiaryById(id);
+
+  if (!entry) {
+    notFound();
+  }
+
+  return (
+    <main className="min-h-screen bg-cream">
+      <div className="max-w-[480px] mx-auto px-4 py-6">
+        <div className="flex items-center gap-4 mb-6">
+          <Link
+            href="/diary/new"
+            className="text-text-sub hover:text-text-main transition-colors"
+            aria-label="返回"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="m15 18-6-6 6-6" />
+            </svg>
+          </Link>
+          <h1 className="text-lg font-bold text-text-main">日记详情</h1>
+        </div>
+        <div className="bg-card rounded-2xl p-4 shadow-sm">
+          <DiaryDetail entry={entry} />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/diary/new/page.tsx
+++ b/src/app/diary/new/page.tsx
@@ -1,0 +1,39 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { DiaryForm } from '@/components/DiaryForm';
+
+export const metadata: Metadata = {
+  title: '写下今天',
+};
+
+export default function NewDiaryPage() {
+  return (
+    <main className="min-h-screen bg-cream">
+      <div className="max-w-[480px] mx-auto px-4 py-6">
+        <div className="flex items-center gap-4 mb-6">
+          <Link
+            href="/"
+            className="text-text-sub hover:text-text-main transition-colors"
+            aria-label="返回"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="m15 18-6-6 6-6" />
+            </svg>
+          </Link>
+          <h1 className="text-lg font-bold text-text-main">写下今天</h1>
+        </div>
+        <DiaryForm />
+      </div>
+    </main>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -28,3 +28,10 @@ body {
   color: var(--color-text-main);
   font-family: var(--font-body), "PingFang SC", "Microsoft YaHei", sans-serif;
 }
+
+/* 输入框聚焦边框统一为 animal-island-ui 焦点黄 */
+input:focus,
+textarea:focus {
+  border-color: #ffcc00 !important;
+  outline: none;
+}

--- a/src/components/DiaryDetail.tsx
+++ b/src/components/DiaryDetail.tsx
@@ -1,0 +1,66 @@
+import dayjs from 'dayjs';
+import Image from 'next/image';
+import type { DiaryEntry, DiaryImage } from '@prisma/client';
+
+interface DiaryDetailProps {
+  entry: DiaryEntry & { images: DiaryImage[] };
+}
+
+const moodMap: Record<string, { label: string; color: string }> = {
+  sweet: { label: '甜甜的', color: '#F7C8D0' },
+  happy: { label: '开心', color: '#B8DDA8' },
+  miss: { label: '想念', color: '#AFC9F7' },
+  calm: { label: '平静', color: '#D8C7E8' },
+  sad: { label: '小难过', color: '#E8C4A0' },
+};
+
+export function DiaryDetail({ entry }: DiaryDetailProps) {
+  const displayTitle =
+    entry.title || `${dayjs(entry.date).format('YYYY年M月D日')} 的心情`;
+  const mood = moodMap[entry.mood] || moodMap.sweet;
+
+  return (
+    <article className="space-y-4">
+      <h1 className="text-xl font-bold text-text-main">{displayTitle}</h1>
+
+      <div className="flex items-center gap-2 text-sm text-text-sub">
+        <span>{dayjs(entry.date).format('YYYY年M月D日')}</span>
+        <span
+          className="flex items-center gap-1 px-2 py-0.5 rounded-full"
+          style={{ backgroundColor: mood.color + '33' }}
+        >
+          <span
+            className="w-2 h-2 rounded-full"
+            style={{ backgroundColor: mood.color }}
+          />
+          {mood.label}
+        </span>
+      </div>
+
+      <p className="text-base text-text-main whitespace-pre-wrap leading-relaxed">
+        {entry.content}
+      </p>
+
+      {entry.images.length > 0 && (
+        <div
+          className={`grid gap-2 ${
+            entry.images.length === 1 ? 'grid-cols-1' : 'grid-cols-2'
+          }`}
+        >
+          {entry.images.map((img) => (
+            <Image
+              key={img.id}
+              src={img.url}
+              alt=""
+              width={800}
+              height={600}
+              className="w-full rounded-lg object-cover"
+              loading="lazy"
+              unoptimized
+            />
+          ))}
+        </div>
+      )}
+    </article>
+  );
+}

--- a/src/components/DiaryForm.tsx
+++ b/src/components/DiaryForm.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import dayjs from 'dayjs';
+import { createDiary } from '@/lib/actions';
+import { useDiaryDraft } from '@/hooks/useDiaryDraft';
+import { MoodSelector, type MoodValue } from './MoodSelector';
+import { ImageUrlInput } from './ImageUrlInput';
+import { validateDiaryForm } from './DiaryForm.validation';
+
+export interface DiaryFormData {
+  date: string;
+  title: string;
+  content: string;
+  mood: MoodValue;
+  images: string[];
+}
+
+const defaultForm: DiaryFormData = {
+  date: dayjs().format('YYYY-MM-DD'),
+  title: '',
+  content: '',
+  mood: 'sweet',
+  images: [],
+};
+
+export function DiaryForm() {
+  const router = useRouter();
+  const [form, setForm, clearDraft] = useDiaryDraft<DiaryFormData>(
+    'diary-draft',
+    defaultForm,
+  );
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState(false);
+
+  const updateField = useCallback(
+    <K extends keyof DiaryFormData>(key: K, value: DiaryFormData[K]) => {
+      setForm((prev) => ({ ...prev, [key]: value }));
+    },
+    [setForm],
+  );
+
+  const handleSubmit = async () => {
+    setError('');
+    setSuccess(false);
+
+    const validation = validateDiaryForm(form);
+    if (!validation.ok) {
+      setError(validation.error!);
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const entry = await createDiary({
+        date: new Date(form.date),
+        title: form.title || undefined,
+        content: form.content,
+        mood: form.mood,
+        images: form.images.length > 0 ? form.images : undefined,
+      });
+      clearDraft();
+      setSuccess(true);
+      setTimeout(() => {
+        router.push(`/diary/${entry.id}`);
+      }, 1500);
+    } catch {
+      setError('保存失败，请稍后重试');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      {success && (
+        <div className="px-4 py-3 rounded-lg bg-primary/20 text-text-main text-sm text-center">
+          今天的心情已经收藏好了
+        </div>
+      )}
+      {error && (
+        <div className="px-4 py-3 rounded-lg bg-red-50 text-red-600 text-sm text-center">
+          {error}
+        </div>
+      )}
+
+      <div className="flex flex-col sm:flex-row gap-4">
+        <input
+          type="date"
+          value={form.date}
+          onChange={(e) => updateField('date', e.target.value)}
+          className="px-3 py-2 rounded-lg border border-border-soft bg-card text-sm text-text-main"
+        />
+        <MoodSelector
+          value={form.mood}
+          onChange={(v) => updateField('mood', v)}
+        />
+      </div>
+
+      <input
+        type="text"
+        value={form.title}
+        onChange={(e) => updateField('title', e.target.value)}
+        placeholder="给今天起个名字（可选）"
+        className="w-full px-3 py-2 rounded-lg border border-border-soft bg-card text-sm text-text-main"
+      />
+
+      <div className="relative">
+        <textarea
+          value={form.content}
+          onChange={(e) => updateField('content', e.target.value)}
+          placeholder="今天发生了什么？"
+          rows={8}
+          className="w-full px-3 py-2 rounded-lg border border-border-soft bg-card text-sm text-text-main resize-none"
+          style={{ fontSize: '16px' }}
+        />
+        <span
+          className={`absolute bottom-2 right-2 text-xs ${
+            form.content.length > 10000 ? 'text-red-500' : 'text-text-sub'
+          }`}
+        >
+          {form.content.length}/10000
+        </span>
+      </div>
+
+      <div className="space-y-1">
+        <label className="text-sm text-text-sub">图片</label>
+        <ImageUrlInput
+          urls={form.images}
+          onChange={(v) => updateField('images', v)}
+        />
+      </div>
+
+      <button
+        onClick={handleSubmit}
+        disabled={saving}
+        className="w-full py-3 rounded-lg bg-primary text-white font-medium disabled:opacity-50 mt-4"
+      >
+        {saving ? '保存中...' : '保存'}
+      </button>
+    </div>
+  );
+}

--- a/src/components/DiaryForm.tsx
+++ b/src/components/DiaryForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import dayjs from 'dayjs';
 import { createDiary } from '@/lib/actions';
@@ -34,6 +34,15 @@ export function DiaryForm() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
 
   const updateField = useCallback(
     <K extends keyof DiaryFormData>(key: K, value: DiaryFormData[K]) => {
@@ -42,7 +51,7 @@ export function DiaryForm() {
     [setForm],
   );
 
-  const handleSubmit = async () => {
+  const handleSubmit = useCallback(async () => {
     setError('');
     setSuccess(false);
 
@@ -63,15 +72,16 @@ export function DiaryForm() {
       });
       clearDraft();
       setSuccess(true);
-      setTimeout(() => {
+      timerRef.current = setTimeout(() => {
         router.push(`/diary/${entry.id}`);
       }, 1500);
-    } catch {
+    } catch (err) {
+      console.error('保存日记失败:', err);
       setError('保存失败，请稍后重试');
     } finally {
       setSaving(false);
     }
-  };
+  }, [form, router, clearDraft]);
 
   return (
     <div className="space-y-4">

--- a/src/components/DiaryForm.tsx
+++ b/src/components/DiaryForm.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import dayjs from 'dayjs';
+import { Input, Button } from 'animal-island-ui';
 import { createDiary } from '@/lib/actions';
 import { useDiaryDraft } from '@/hooks/useDiaryDraft';
 import { MoodSelector, type MoodValue } from './MoodSelector';
@@ -109,12 +110,10 @@ export function DiaryForm() {
         />
       </div>
 
-      <input
-        type="text"
+      <Input
         value={form.title}
         onChange={(e) => updateField('title', e.target.value)}
         placeholder="给今天起个名字（可选）"
-        className="w-full px-3 py-2 rounded-lg border border-border-soft bg-card text-sm text-text-main"
       />
 
       <div className="relative">
@@ -143,13 +142,16 @@ export function DiaryForm() {
         />
       </div>
 
-      <button
-        onClick={handleSubmit}
+      <Button
+        type="primary"
+        block
+        loading={saving}
         disabled={saving}
-        className="w-full py-3 rounded-lg bg-primary text-white font-medium disabled:opacity-50 mt-4"
+        htmlType="button"
+        onClick={handleSubmit}
       >
-        {saving ? '保存中...' : '保存'}
-      </button>
+        保存
+      </Button>
     </div>
   );
 }

--- a/src/components/DiaryForm.validation.ts
+++ b/src/components/DiaryForm.validation.ts
@@ -1,0 +1,19 @@
+export interface DiaryFormData {
+  date: string;
+  title: string;
+  content: string;
+  mood: string;
+  images: string[];
+}
+
+export function validateDiaryForm(
+  data: DiaryFormData,
+): { ok: boolean; error?: string } {
+  if (!data.content.trim()) {
+    return { ok: false, error: '写点什么吧' };
+  }
+  if (data.content.length > 10000) {
+    return { ok: false, error: '正文太长了，最多 10000 字' };
+  }
+  return { ok: true };
+}

--- a/src/components/ImageUrlInput.tsx
+++ b/src/components/ImageUrlInput.tsx
@@ -31,7 +31,7 @@ export function ImageUrlInput({ urls, onChange }: ImageUrlInputProps) {
   return (
     <div className="space-y-2">
       {urls.map((url, index) => (
-        <div key={`${url}-${index}`} className="flex items-center gap-2">
+        <div key={index} className="flex items-center gap-2">
           <span className="flex-1 text-sm text-text-sub truncate">{url}</span>
           <button
             type="button"
@@ -50,6 +50,12 @@ export function ImageUrlInput({ urls, onChange }: ImageUrlInputProps) {
           onChange={(e) => {
             setInput(e.target.value);
             if (error) setError('');
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              addUrl();
+            }
           }}
           placeholder="粘贴图片链接"
           className="flex-1 px-3 py-2 rounded-lg border border-border-soft bg-card text-sm"

--- a/src/components/ImageUrlInput.tsx
+++ b/src/components/ImageUrlInput.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useState } from 'react';
+
+interface ImageUrlInputProps {
+  urls: string[];
+  onChange: (urls: string[]) => void;
+}
+
+export function ImageUrlInput({ urls, onChange }: ImageUrlInputProps) {
+  const [input, setInput] = useState('');
+  const [error, setError] = useState('');
+
+  const addUrl = () => {
+    const trimmed = input.trim();
+    if (!trimmed) return;
+    try {
+      new URL(trimmed);
+      onChange([...urls, trimmed]);
+      setInput('');
+      setError('');
+    } catch {
+      setError('请输入有效的图片地址');
+    }
+  };
+
+  const removeUrl = (index: number) => {
+    onChange(urls.filter((_, i) => i !== index));
+  };
+
+  return (
+    <div className="space-y-2">
+      {urls.map((url, index) => (
+        <div key={`${url}-${index}`} className="flex items-center gap-2">
+          <span className="flex-1 text-sm text-text-sub truncate">{url}</span>
+          <button
+            type="button"
+            onClick={() => removeUrl(index)}
+            className="text-sm text-accent hover:text-text-main"
+          >
+            删除
+          </button>
+        </div>
+      ))}
+
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => {
+            setInput(e.target.value);
+            if (error) setError('');
+          }}
+          placeholder="粘贴图片链接"
+          className="flex-1 px-3 py-2 rounded-lg border border-border-soft bg-card text-sm"
+        />
+        <button
+          type="button"
+          onClick={addUrl}
+          className="px-3 py-2 rounded-lg bg-primary text-white text-sm font-medium"
+        >
+          添加
+        </button>
+      </div>
+      {error && <p className="text-sm text-red-500">{error}</p>}
+    </div>
+  );
+}

--- a/src/components/MoodSelector.tsx
+++ b/src/components/MoodSelector.tsx
@@ -54,8 +54,14 @@ export function MoodSelector({ value, onChange }: MoodSelectorProps) {
         <motion.span
           className="w-3 h-3 rounded-full"
           style={{ backgroundColor: selected.color }}
-          animate={{ scale: [1, 1.3, 1] }}
-          transition={{ type: 'spring', stiffness: 300, damping: 10 }}
+          animate={{ scale: 1.3 }}
+          transition={{
+            type: 'spring',
+            stiffness: 300,
+            damping: 10,
+            repeat: 1,
+            repeatType: 'reverse',
+          }}
           key={selected.value}
         />
         <span className="text-sm text-text-main">{selected.label}</span>

--- a/src/components/MoodSelector.tsx
+++ b/src/components/MoodSelector.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 export const MOODS = [
   { value: 'sweet', label: '甜甜的', color: '#F7C8D0' },
@@ -19,15 +19,36 @@ interface MoodSelectorProps {
 
 export function MoodSelector({ value, onChange }: MoodSelectorProps) {
   const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
   const selected = MOODS.find((m) => m.value === value) ?? MOODS[0];
 
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    if (open) {
+      document.addEventListener('mousedown', handleClickOutside);
+      document.addEventListener('keydown', handleKeyDown);
+    }
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open]);
+
   return (
-    <div className="relative">
+    <div className="relative" ref={ref}>
       <button
         type="button"
         onClick={() => setOpen(!open)}
         className="flex items-center gap-2 px-3 py-2 rounded-lg border border-border-soft bg-card"
         aria-expanded={open}
+        aria-haspopup="listbox"
       >
         <span
           className="w-3 h-3 rounded-full"
@@ -37,11 +58,16 @@ export function MoodSelector({ value, onChange }: MoodSelectorProps) {
       </button>
 
       {open && (
-        <div className="absolute z-10 mt-1 w-full min-w-[120px] rounded-lg border border-border-soft bg-card shadow-lg overflow-hidden">
+        <div
+          className="absolute z-10 mt-1 w-full min-w-[120px] rounded-lg border border-border-soft bg-card shadow-lg overflow-hidden"
+          role="listbox"
+        >
           {MOODS.map((mood) => (
             <button
               key={mood.value}
               type="button"
+              role="option"
+              aria-selected={mood.value === value}
               onClick={() => {
                 onChange(mood.value);
                 setOpen(false);

--- a/src/components/MoodSelector.tsx
+++ b/src/components/MoodSelector.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useState } from 'react';
+
+export const MOODS = [
+  { value: 'sweet', label: '甜甜的', color: '#F7C8D0' },
+  { value: 'happy', label: '开心', color: '#B8DDA8' },
+  { value: 'miss', label: '想念', color: '#AFC9F7' },
+  { value: 'calm', label: '平静', color: '#D8C7E8' },
+  { value: 'sad', label: '小难过', color: '#E8C4A0' },
+] as const;
+
+export type MoodValue = (typeof MOODS)[number]['value'];
+
+interface MoodSelectorProps {
+  value: MoodValue;
+  onChange: (value: MoodValue) => void;
+}
+
+export function MoodSelector({ value, onChange }: MoodSelectorProps) {
+  const [open, setOpen] = useState(false);
+  const selected = MOODS.find((m) => m.value === value) ?? MOODS[0];
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="flex items-center gap-2 px-3 py-2 rounded-lg border border-border-soft bg-card"
+        aria-expanded={open}
+      >
+        <span
+          className="w-3 h-3 rounded-full"
+          style={{ backgroundColor: selected.color }}
+        />
+        <span className="text-sm text-text-main">{selected.label}</span>
+      </button>
+
+      {open && (
+        <div className="absolute z-10 mt-1 w-full min-w-[120px] rounded-lg border border-border-soft bg-card shadow-lg overflow-hidden">
+          {MOODS.map((mood) => (
+            <button
+              key={mood.value}
+              type="button"
+              onClick={() => {
+                onChange(mood.value);
+                setOpen(false);
+              }}
+              className="flex items-center gap-2 w-full px-3 py-2 hover:bg-cream text-left"
+            >
+              <span
+                className="w-3 h-3 rounded-full"
+                style={{ backgroundColor: mood.color }}
+              />
+              <span className="text-sm text-text-main">{mood.label}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/MoodSelector.tsx
+++ b/src/components/MoodSelector.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
 
 export const MOODS = [
   { value: 'sweet', label: '甜甜的', color: '#F7C8D0' },
@@ -50,39 +51,50 @@ export function MoodSelector({ value, onChange }: MoodSelectorProps) {
         aria-expanded={open}
         aria-haspopup="listbox"
       >
-        <span
+        <motion.span
           className="w-3 h-3 rounded-full"
           style={{ backgroundColor: selected.color }}
+          animate={{ scale: [1, 1.3, 1] }}
+          transition={{ type: 'spring', stiffness: 300, damping: 10 }}
+          key={selected.value}
         />
         <span className="text-sm text-text-main">{selected.label}</span>
       </button>
 
-      {open && (
-        <div
-          className="absolute z-10 mt-1 w-full min-w-[120px] rounded-lg border border-border-soft bg-card shadow-lg overflow-hidden"
-          role="listbox"
-        >
-          {MOODS.map((mood) => (
-            <button
-              key={mood.value}
-              type="button"
-              role="option"
-              aria-selected={mood.value === value}
-              onClick={() => {
-                onChange(mood.value);
-                setOpen(false);
-              }}
-              className="flex items-center gap-2 w-full px-3 py-2 hover:bg-cream text-left"
-            >
-              <span
-                className="w-3 h-3 rounded-full"
-                style={{ backgroundColor: mood.color }}
-              />
-              <span className="text-sm text-text-main">{mood.label}</span>
-            </button>
-          ))}
-        </div>
-      )}
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            className="absolute z-10 mt-1 w-full min-w-[120px] rounded-lg border border-border-soft bg-card shadow-lg overflow-hidden"
+            role="listbox"
+            initial={{ opacity: 0, y: -4, scale: 0.96 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: -4, scale: 0.96 }}
+            transition={{ type: 'spring', stiffness: 400, damping: 25 }}
+          >
+            {MOODS.map((mood) => (
+              <button
+                key={mood.value}
+                type="button"
+                role="option"
+                aria-selected={mood.value === value}
+                onClick={() => {
+                  onChange(mood.value);
+                  setOpen(false);
+                }}
+                className="flex items-center gap-2 w-full px-3 py-2 hover:bg-cream text-left"
+              >
+                <motion.span
+                  className="w-3 h-3 rounded-full"
+                  style={{ backgroundColor: mood.color }}
+                  whileTap={{ scale: 0.8 }}
+                  transition={{ type: 'spring', stiffness: 400, damping: 15 }}
+                />
+                <span className="text-sm text-text-main">{mood.label}</span>
+              </button>
+            ))}
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/src/components/SecretWriteEntry.tsx
+++ b/src/components/SecretWriteEntry.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useRef, useCallback } from 'react';
+
+interface SecretWriteEntryProps {
+  children: React.ReactNode;
+}
+
+export default function SecretWriteEntry({ children }: SecretWriteEntryProps) {
+  const router = useRouter();
+  const clickCountRef = useRef(0);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleClick = useCallback(() => {
+    clickCountRef.current += 1;
+
+    if (clickCountRef.current === 1) {
+      timerRef.current = setTimeout(() => {
+        clickCountRef.current = 0;
+      }, 500);
+    }
+
+    if (clickCountRef.current >= 3) {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      clickCountRef.current = 0;
+      router.push('/diary/new');
+    }
+  }, [router]);
+
+  return (
+    <div
+      onClick={handleClick}
+      className="cursor-default select-none"
+      title=""
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/__tests__/DiaryForm.validation.test.ts
+++ b/src/components/__tests__/DiaryForm.validation.test.ts
@@ -1,0 +1,34 @@
+import { validateDiaryForm } from '../DiaryForm.validation';
+
+describe('validateDiaryForm', () => {
+  const base = {
+    date: '2025-01-15',
+    title: '',
+    content: '今天很开心',
+    mood: 'sweet' as const,
+    images: [] as string[],
+  };
+
+  test('空正文返回错误', () => {
+    const result = validateDiaryForm({ ...base, content: '' });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('写点什么吧');
+  });
+
+  test('空白正文返回错误', () => {
+    const result = validateDiaryForm({ ...base, content: '   ' });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('写点什么吧');
+  });
+
+  test('10000 字符正文通过', () => {
+    const result = validateDiaryForm({ ...base, content: 'a'.repeat(10000) });
+    expect(result.ok).toBe(true);
+  });
+
+  test('10001 字符正文失败', () => {
+    const result = validateDiaryForm({ ...base, content: 'a'.repeat(10001) });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('正文太长了，最多 10000 字');
+  });
+});

--- a/src/components/__tests__/ImageUrlInput.test.tsx
+++ b/src/components/__tests__/ImageUrlInput.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ImageUrlInput } from '../ImageUrlInput';
+
+describe('ImageUrlInput', () => {
+  test('添加有效 URL', () => {
+    const onChange = jest.fn();
+    render(<ImageUrlInput urls={[]} onChange={onChange} />);
+
+    fireEvent.change(screen.getByPlaceholderText('粘贴图片链接'), {
+      target: { value: 'https://example.com/photo.jpg' },
+    });
+    fireEvent.click(screen.getByText('添加'));
+
+    expect(onChange).toHaveBeenCalledWith(['https://example.com/photo.jpg']);
+  });
+
+  test('拒绝无效 URL', () => {
+    const onChange = jest.fn();
+    render(<ImageUrlInput urls={[]} onChange={onChange} />);
+
+    fireEvent.change(screen.getByPlaceholderText('粘贴图片链接'), {
+      target: { value: 'not-a-url' },
+    });
+    fireEvent.click(screen.getByText('添加'));
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByText('请输入有效的图片地址')).toBeInTheDocument();
+  });
+
+  test('删除 URL', () => {
+    const onChange = jest.fn();
+    render(
+      <ImageUrlInput
+        urls={['https://example.com/1.jpg', 'https://example.com/2.jpg']}
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.click(screen.getAllByText('删除')[0]);
+
+    expect(onChange).toHaveBeenCalledWith(['https://example.com/2.jpg']);
+  });
+});

--- a/src/components/__tests__/ImageUrlInput.test.tsx
+++ b/src/components/__tests__/ImageUrlInput.test.tsx
@@ -14,6 +14,29 @@ describe('ImageUrlInput', () => {
     expect(onChange).toHaveBeenCalledWith(['https://example.com/photo.jpg']);
   });
 
+  test('按 Enter 添加有效 URL', () => {
+    const onChange = jest.fn();
+    render(<ImageUrlInput urls={[]} onChange={onChange} />);
+
+    fireEvent.change(screen.getByPlaceholderText('粘贴图片链接'), {
+      target: { value: 'https://example.com/photo.jpg' },
+    });
+    fireEvent.keyDown(screen.getByPlaceholderText('粘贴图片链接'), {
+      key: 'Enter',
+    });
+
+    expect(onChange).toHaveBeenCalledWith(['https://example.com/photo.jpg']);
+  });
+
+  test('空输入点击添加不触发 onChange', () => {
+    const onChange = jest.fn();
+    render(<ImageUrlInput urls={[]} onChange={onChange} />);
+
+    fireEvent.click(screen.getByText('添加'));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   test('拒绝无效 URL', () => {
     const onChange = jest.fn();
     render(<ImageUrlInput urls={[]} onChange={onChange} />);

--- a/src/components/__tests__/MoodSelector.test.tsx
+++ b/src/components/__tests__/MoodSelector.test.tsx
@@ -1,46 +1,59 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MotionConfig } from 'framer-motion';
 import { MoodSelector, MOODS } from '../MoodSelector';
+
+function renderWithMotion(ui: React.ReactElement) {
+  return render(
+    <MotionConfig reducedMotion="always">{ui}</MotionConfig>,
+  );
+}
 
 describe('MoodSelector', () => {
   test('默认渲染当前选中项', () => {
-    render(<MoodSelector value="sweet" onChange={jest.fn()} />);
+    renderWithMotion(<MoodSelector value="sweet" onChange={jest.fn()} />);
     expect(screen.getByText('甜甜的')).toBeInTheDocument();
   });
 
   test('点击展开下拉面板', () => {
-    render(<MoodSelector value="sweet" onChange={jest.fn()} />);
+    renderWithMotion(<MoodSelector value="sweet" onChange={jest.fn()} />);
     fireEvent.click(screen.getByRole('button'));
     MOODS.forEach((mood) => {
       expect(screen.getAllByText(mood.label).length).toBeGreaterThanOrEqual(1);
     });
   });
 
-  test('选择选项后触发 onChange 并关闭面板', () => {
+  test('选择选项后触发 onChange 并关闭面板', async () => {
     const onChange = jest.fn();
-    render(<MoodSelector value="sweet" onChange={onChange} />);
+    renderWithMotion(<MoodSelector value="sweet" onChange={onChange} />);
 
     fireEvent.click(screen.getByRole('button'));
     fireEvent.click(screen.getByText('开心'));
 
     expect(onChange).toHaveBeenCalledWith('happy');
-    expect(screen.queryByText('想念')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText('想念')).not.toBeInTheDocument();
+    });
   });
 
-  test('点击外部关闭下拉面板', () => {
-    render(<MoodSelector value="sweet" onChange={jest.fn()} />);
+  test('点击外部关闭下拉面板', async () => {
+    renderWithMotion(<MoodSelector value="sweet" onChange={jest.fn()} />);
     fireEvent.click(screen.getByRole('button'));
     expect(screen.getByText('开心')).toBeInTheDocument();
 
     fireEvent.mouseDown(document.body);
-    expect(screen.queryByText('开心')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText('开心')).not.toBeInTheDocument();
+    });
   });
 
-  test('按 Escape 关闭下拉面板', () => {
-    render(<MoodSelector value="sweet" onChange={jest.fn()} />);
+  test('按 Escape 关闭下拉面板', async () => {
+    renderWithMotion(<MoodSelector value="sweet" onChange={jest.fn()} />);
     fireEvent.click(screen.getByRole('button'));
     expect(screen.getByText('开心')).toBeInTheDocument();
 
     fireEvent.keyDown(document, { key: 'Escape' });
-    expect(screen.queryByText('开心')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText('开心')).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/__tests__/MoodSelector.test.tsx
+++ b/src/components/__tests__/MoodSelector.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MoodSelector, MOODS } from '../MoodSelector';
+
+describe('MoodSelector', () => {
+  test('默认渲染当前选中项', () => {
+    render(<MoodSelector value="sweet" onChange={jest.fn()} />);
+    expect(screen.getByText('甜甜的')).toBeInTheDocument();
+  });
+
+  test('点击展开下拉面板', () => {
+    render(<MoodSelector value="sweet" onChange={jest.fn()} />);
+    fireEvent.click(screen.getByRole('button'));
+    MOODS.forEach((mood) => {
+      expect(screen.getAllByText(mood.label).length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  test('选择选项后触发 onChange 并关闭面板', () => {
+    const onChange = jest.fn();
+    render(<MoodSelector value="sweet" onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole('button'));
+    fireEvent.click(screen.getByText('开心'));
+
+    expect(onChange).toHaveBeenCalledWith('happy');
+    expect(screen.queryByText('想念')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/MoodSelector.test.tsx
+++ b/src/components/__tests__/MoodSelector.test.tsx
@@ -25,4 +25,22 @@ describe('MoodSelector', () => {
     expect(onChange).toHaveBeenCalledWith('happy');
     expect(screen.queryByText('想念')).not.toBeInTheDocument();
   });
+
+  test('点击外部关闭下拉面板', () => {
+    render(<MoodSelector value="sweet" onChange={jest.fn()} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByText('开心')).toBeInTheDocument();
+
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByText('开心')).not.toBeInTheDocument();
+  });
+
+  test('按 Escape 关闭下拉面板', () => {
+    render(<MoodSelector value="sweet" onChange={jest.fn()} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByText('开心')).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByText('开心')).not.toBeInTheDocument();
+  });
 });

--- a/src/hooks/__tests__/useDiaryDraft.test.ts
+++ b/src/hooks/__tests__/useDiaryDraft.test.ts
@@ -1,0 +1,61 @@
+import { renderHook, act } from '@testing-library/react';
+import { useDiaryDraft } from '../useDiaryDraft';
+
+describe('useDiaryDraft', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('初始化返回默认值', () => {
+    const { result } = renderHook(() =>
+      useDiaryDraft('diary-draft', { content: '' }),
+    );
+    expect(result.current[0]).toEqual({ content: '' });
+  });
+
+  test('500ms 防抖后保存到 localStorage', () => {
+    jest.useFakeTimers();
+    const { result } = renderHook(() =>
+      useDiaryDraft('diary-draft', { content: '' }),
+    );
+
+    act(() => {
+      result.current[1]({ content: 'hello' });
+    });
+
+    expect(localStorage.getItem('diary-draft')).toBeNull();
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(localStorage.getItem('diary-draft')).toBe(
+      JSON.stringify({ content: 'hello' }),
+    );
+    jest.useRealTimers();
+  });
+
+  test('挂载时恢复 localStorage 草稿', () => {
+    localStorage.setItem('diary-draft', JSON.stringify({ content: 'restored' }));
+
+    const { result } = renderHook(() =>
+      useDiaryDraft('diary-draft', { content: '' }),
+    );
+
+    expect(result.current[0]).toEqual({ content: 'restored' });
+  });
+
+  test('clearDraft 清除 localStorage', () => {
+    localStorage.setItem('diary-draft', JSON.stringify({ content: 'hello' }));
+
+    const { result } = renderHook(() =>
+      useDiaryDraft('diary-draft', { content: '' }),
+    );
+
+    act(() => {
+      result.current[2]();
+    });
+
+    expect(localStorage.getItem('diary-draft')).toBeNull();
+  });
+});

--- a/src/hooks/__tests__/useDiaryDraft.test.ts
+++ b/src/hooks/__tests__/useDiaryDraft.test.ts
@@ -45,7 +45,7 @@ describe('useDiaryDraft', () => {
     expect(result.current[0]).toEqual({ content: 'restored' });
   });
 
-  test('clearDraft 清除 localStorage', () => {
+  test('clearDraft 清除 localStorage 并同步 state', () => {
     localStorage.setItem('diary-draft', JSON.stringify({ content: 'hello' }));
 
     const { result } = renderHook(() =>
@@ -57,5 +57,6 @@ describe('useDiaryDraft', () => {
     });
 
     expect(localStorage.getItem('diary-draft')).toBeNull();
+    expect(result.current[0]).toEqual({ content: '' });
   });
 });

--- a/src/hooks/useDiaryDraft.ts
+++ b/src/hooks/useDiaryDraft.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 export function useDiaryDraft<T>(key: string, defaultValue: T) {
   const [draft, setDraft] = useState<T>(() => {
@@ -16,6 +16,12 @@ export function useDiaryDraft<T>(key: string, defaultValue: T) {
     return defaultValue;
   });
 
+  const defaultValueRef = useRef(defaultValue);
+
+  useEffect(() => {
+    defaultValueRef.current = defaultValue;
+  }, [defaultValue]);
+
   useEffect(() => {
     if (typeof window === 'undefined') return;
     const timer = setTimeout(() => {
@@ -27,7 +33,7 @@ export function useDiaryDraft<T>(key: string, defaultValue: T) {
   const clearDraft = () => {
     if (typeof window === 'undefined') return;
     localStorage.removeItem(key);
-    setDraft(defaultValue);
+    setDraft(defaultValueRef.current);
   };
 
   return [draft, setDraft, clearDraft] as const;

--- a/src/hooks/useDiaryDraft.ts
+++ b/src/hooks/useDiaryDraft.ts
@@ -28,6 +28,7 @@ export function useDiaryDraft<T>(key: string, defaultValue: T) {
   const clearDraft = () => {
     if (typeof window === 'undefined') return;
     localStorage.removeItem(key);
+    setDraft(defaultValue);
   };
 
   return [draft, setDraft, clearDraft] as const;

--- a/src/hooks/useDiaryDraft.ts
+++ b/src/hooks/useDiaryDraft.ts
@@ -1,25 +1,20 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 
 export function useDiaryDraft<T>(key: string, defaultValue: T) {
-  const [draft, setDraft] = useState<T>(defaultValue);
-  const defaultValueRef = useRef(defaultValue);
-
-  // 保持 defaultValueRef 始终最新
-  defaultValueRef.current = defaultValue;
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
+  const [draft, setDraft] = useState<T>(() => {
+    if (typeof window === 'undefined') return defaultValue;
     const saved = localStorage.getItem(key);
     if (saved) {
       try {
-        setDraft(JSON.parse(saved));
+        return JSON.parse(saved);
       } catch {
         localStorage.removeItem(key);
       }
     }
-  }, [key]);
+    return defaultValue;
+  });
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -32,7 +27,7 @@ export function useDiaryDraft<T>(key: string, defaultValue: T) {
   const clearDraft = () => {
     if (typeof window === 'undefined') return;
     localStorage.removeItem(key);
-    setDraft(defaultValueRef.current);
+    setDraft(defaultValue);
   };
 
   return [draft, setDraft, clearDraft] as const;

--- a/src/hooks/useDiaryDraft.ts
+++ b/src/hooks/useDiaryDraft.ts
@@ -1,0 +1,34 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+export function useDiaryDraft<T>(key: string, defaultValue: T) {
+  const [draft, setDraft] = useState<T>(defaultValue);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const saved = localStorage.getItem(key);
+    if (saved) {
+      try {
+        setDraft(JSON.parse(saved));
+      } catch {
+        localStorage.removeItem(key);
+      }
+    }
+  }, [key]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const timer = setTimeout(() => {
+      localStorage.setItem(key, JSON.stringify(draft));
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [draft, key]);
+
+  const clearDraft = () => {
+    if (typeof window === 'undefined') return;
+    localStorage.removeItem(key);
+  };
+
+  return [draft, setDraft, clearDraft] as const;
+}

--- a/src/hooks/useDiaryDraft.ts
+++ b/src/hooks/useDiaryDraft.ts
@@ -1,9 +1,13 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 export function useDiaryDraft<T>(key: string, defaultValue: T) {
   const [draft, setDraft] = useState<T>(defaultValue);
+  const defaultValueRef = useRef(defaultValue);
+
+  // 保持 defaultValueRef 始终最新
+  defaultValueRef.current = defaultValue;
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -28,7 +32,7 @@ export function useDiaryDraft<T>(key: string, defaultValue: T) {
   const clearDraft = () => {
     if (typeof window === 'undefined') return;
     localStorage.removeItem(key);
-    setDraft(defaultValue);
+    setDraft(defaultValueRef.current);
   };
 
   return [draft, setDraft, clearDraft] as const;

--- a/src/lib/test-polyfill.ts
+++ b/src/lib/test-polyfill.ts
@@ -1,6 +1,4 @@
-import '@testing-library/jest-dom';
 import { TextEncoder, TextDecoder } from 'util';
-import { prisma } from './prisma';
 
 if (typeof globalThis.TextEncoder === 'undefined') {
   globalThis.TextEncoder = TextEncoder as typeof globalThis.TextEncoder;
@@ -8,7 +6,3 @@ if (typeof globalThis.TextEncoder === 'undefined') {
 if (typeof globalThis.TextDecoder === 'undefined') {
   globalThis.TextDecoder = TextDecoder as typeof globalThis.TextDecoder;
 }
-
-afterAll(async () => {
-  await prisma.$disconnect();
-});

--- a/src/lib/test-setup.ts
+++ b/src/lib/test-setup.ts
@@ -1,13 +1,5 @@
 import '@testing-library/jest-dom';
-import { TextEncoder, TextDecoder } from 'util';
 import { prisma } from './prisma';
-
-if (typeof globalThis.TextEncoder === 'undefined') {
-  globalThis.TextEncoder = TextEncoder as typeof globalThis.TextEncoder;
-}
-if (typeof globalThis.TextDecoder === 'undefined') {
-  globalThis.TextDecoder = TextDecoder as typeof globalThis.TextDecoder;
-}
 
 afterAll(async () => {
   await prisma.$disconnect();


### PR DESCRIPTION
Closes #6

## 变更摘要

实现 Issue #6 要求的全部功能，包括新增日记表单、心情选择器、外链图片 URL 输入、草稿自动保存，以及极简日记详情页占位。

### 新增页面

| 页面 | 说明 |
|------|------|
| `/diary/new` | 新增日记表单页 |
| `/diary/[id]` | 极简日记详情页占位（Issue #7 完成前的过渡方案） |

### 新增组件

| 组件 | 说明 |
|------|------|
| `DiaryForm` | 表单主组件，集成草稿、校验、提交、跳转 |
| `MoodSelector` | 心情下拉选择器，5 种心情，支持外部点击/Escape 关闭 |
| `ImageUrlInput` | 外链图片 URL 动态列表，支持添加/删除/Enter 快捷键 |
| `DiaryDetail` | 极简详情页展示组件 |
| `SecretWriteEntry` | 封面页隐蔽入口：连续点击统计区域 3 次进入写日记 |
| `useDiaryDraft` | localStorage 草稿自动保存 hook（500ms 防抖） |
| `validateDiaryForm` | 表单校验纯函数（正文非空、10000 字符上限） |

### 技术决策

- **表单状态管理**：采用轻量 `useState` + 自定义 hook，不引入 `react-hook-form`
- **心情选择器**：下拉形式（Issue 确认方案 C），后台记录场景简洁优先
- **草稿保存**：`localStorage` key 为 `diary-draft`，提交成功后自动清除
- **保存跳转**：成功后显示提示"今天的心情已经收藏好了"，1.5s 后跳转到 `/diary/[id]`
- **封面页入口**：
  - "翻开日记"按钮指向最新日记详情页（修复原 `/diary` 404）
  - 无日记时显示"写下第一篇"
  - 隐蔽入口：连续点击统计信息区域 3 次进入 `/diary/new`

### 测试覆盖

- `useDiaryDraft.test.ts`：4 个测试（初始化、防抖保存、恢复、清除）
- `MoodSelector.test.tsx`：5 个测试（渲染、展开、选择、外部关闭、Escape）
- `ImageUrlInput.test.tsx`：5 个测试（添加、Enter 添加、空输入、无效 URL、删除）
- `DiaryForm.validation.test.ts`：4 个测试（空、空白、边界 10000/10001）
- 现有 Server Actions 测试：19 个，无回归

**总计：37 个测试全部通过**

### 验收标准核对

- [x] 日期选择器默认选中今天
- [x] 标题为空时允许提交（传 undefined，详情页显示默认标题）
- [x] 心情选择器有 5 个选项，默认选中"甜甜的"
- [x] 正文为空时阻止提交并显示错误提示
- [x] 可以添加多个外链图片 URL
- [x] 可以删除已添加的图片 URL
- [x] 输入过程中每 500ms 自动保存草稿到 localStorage
- [x] 刷新页面后草稿自动恢复
- [x] 保存成功后显示顶部提示并跳转到 `/diary/[id]`
- [x] 表单使用 Tailwind 样式（animal-island-ui 组件未强制使用，与现有 SettingsForm 风格一致）
- [x] 输入框聚焦边框为项目主题色
- [x] 移动端输入框字号 ≥ 16px
- [x] 正文刚好 10000 字符允许提交，10001 字符阻止
- [x] 无效图片 URL 前端拒绝添加
- [x] 快速连续点击保存按钮防抖（loading 态 + 禁用）

### 验证结果

```bash
pnpm test   # 37 passed, 0 failed
pnpm lint   # 0 errors, 0 warnings
pnpm build  # 成功，/diary/new 与 /diary/[id] 均已编译
```