### PR TITLE
feat: 时间线目录页 /diary + 单篇页时间线入口 (Issue #7)

### DIFF
--- a/docs/superpowers/plans/2026-05-03-diary-timeline.md
+++ b/docs/superpowers/plans/2026-05-03-diary-timeline.md
@@ -1,0 +1,667 @@
+# 时间线目录页 实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 实现 `/diary` 时间线目录页（按月分组 + sticky 月份标签 + 时间轴列表）以及 `/diary/[id]` 单篇页底部"时间线"入口。
+
+**Architecture:** Server-first 实现。`/diary` 页面在服务端获取日记列表、按月分组 Map，传给纯渲染组件 `DiaryTimeline`。`BackButton` 是唯一 Client Component（`router.back()` + `window.history.length` fallback）。`getDiaryList` 增加 `createdAt` 二级排序键，保证目录顺序与翻页顺序一致。
+
+**Tech Stack:** Next.js 16 App Router、React 19、Tailwind CSS v4、animal-island-ui、Jest + ts-jest + React Testing Library、Prisma、dayjs。
+
+**Spec:** `docs/superpowers/specs/2026-05-03-diary-timeline-design.md`
+
+---
+
+## File Structure
+
+| 文件 | 操作 | 职责 |
+|------|------|------|
+| `src/lib/actions.ts` | 修改 | `getDiaryList` 增加 `createdAt` 二级排序 |
+| `src/lib/__tests__/actions.test.ts` | 修改 | 补充同日多篇排序测试用例 |
+| `src/lib/dayjs.ts` | 创建 | 集中初始化 dayjs 中文 locale |
+| `src/components/BackButton.tsx` | 创建 | Client Component：router.back() + fallback `/` |
+| `src/components/__tests__/BackButton.test.tsx` | 创建 | BackButton 单元测试 |
+| `src/components/DiaryTimeline.tsx` | 创建 | Server Component：sticky 月份标签 + 时间轴列表 |
+| `src/components/__tests__/DiaryTimeline.test.tsx` | 创建 | DiaryTimeline 单元测试 |
+| `src/app/diary/page.tsx` | 创建 | Server Component：数据获取、按月分组、空状态分支 |
+| `src/app/diary/[id]/page.tsx` | 修改 | 内容卡片下方追加"时间线"入口链接 |
+
+---
+
+## Task 1: 调整 `getDiaryList` 排序 + 补充回归测试
+
+**Files:**
+- Modify: `src/lib/actions.ts:41-46`
+- Modify: `src/lib/__tests__/actions.test.ts`
+
+**目标:** 将 `getDiaryList` 的 `orderBy` 从单字段 `{ date: 'desc' }` 改为 `[{ date: 'desc' }, { createdAt: 'desc' }]`，并补充测试验证同日多篇按创建时间倒序。
+
+- [ ] **Step 1: 修改 `src/lib/actions.ts`**
+
+```typescript
+export async function getDiaryList() {
+  return prisma.diaryEntry.findMany({
+    orderBy: [{ date: 'desc' }, { createdAt: 'desc' }],
+    include: { images: true },
+  });
+}
+```
+
+- [ ] **Step 2: 在 `src/lib/__tests__/actions.test.ts` 的 `describe('Diary Actions')` 内，现有 `getDiaryList` 测试之后追加新测试**
+
+```typescript
+  test('getDiaryList sorts same-day entries by createdAt desc', async () => {
+    const sameDate = new Date('2025-01-15');
+    const first = await createDiary({ date: sameDate, title: 'First', content: 'a' });
+    const second = await createDiary({ date: sameDate, title: 'Second', content: 'b' });
+    const third = await createDiary({ date: sameDate, title: 'Third', content: 'c' });
+
+    // 手动调整 createdAt 确保顺序可控
+    const base = dayjs('2025-01-15T10:00:00.000Z');
+    await prisma.diaryEntry.update({ where: { id: first.id }, data: { createdAt: base.toDate() } });
+    await prisma.diaryEntry.update({ where: { id: second.id }, data: { createdAt: base.add(1, 'hour').toDate() } });
+    await prisma.diaryEntry.update({ where: { id: third.id }, data: { createdAt: base.add(2, 'hour').toDate() } });
+
+    const list = await getDiaryList();
+    expect(list.map((d) => d.title)).toEqual(['Third', 'Second', 'First']);
+  });
+```
+
+- [ ] **Step 3: 运行测试验证通过**
+
+```bash
+pnpm test -- --testPathPattern=actions.test.ts
+```
+
+Expected: 全部通过，包括新增用例。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/actions.ts src/lib/__tests__/actions.test.ts
+git commit -m "$(cat <<'EOF'
+fix(actions): getDiaryList 增加 createdAt 二级排序(Issue #7)
+
+保证目录顺序与翻页顺序一致。
+EOF
+)"
+```
+
+---
+
+## Task 2: 创建 `src/lib/dayjs.ts`
+
+**Files:**
+- Create: `src/lib/dayjs.ts`
+
+**目标:** 集中初始化 dayjs 中文 locale，供需要中文星期的模块统一引入。
+
+- [ ] **Step 1: 创建文件**
+
+```typescript
+import dayjs from 'dayjs';
+import 'dayjs/locale/zh-cn';
+
+dayjs.locale('zh-cn');
+
+export default dayjs;
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/lib/dayjs.ts
+git commit -m "$(cat <<'EOF'
+feat(lib): 集中初始化 dayjs 中文 locale(Issue #7)
+EOF
+)"
+```
+
+---
+
+## Task 3: 创建 `BackButton` 组件 + 测试
+
+**Files:**
+- Create: `src/components/BackButton.tsx`
+- Create: `src/components/__tests__/BackButton.test.tsx`
+
+**目标:** Client Component，点击时优先 `router.back()`，若浏览器历史栈为空（`window.history.length <= 1`）则 fallback 到 `/`。
+
+- [ ] **Step 1: 写测试**
+
+`src/components/__tests__/BackButton.test.tsx`:
+
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BackButton } from '../BackButton';
+
+const mockBack = jest.fn();
+const mockPush = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    back: mockBack,
+    push: mockPush,
+  }),
+}));
+
+describe('BackButton', () => {
+  beforeEach(() => {
+    mockBack.mockClear();
+    mockPush.mockClear();
+  });
+
+  test('calls router.back when history.length > 1', () => {
+    Object.defineProperty(window, 'history', {
+      value: { length: 2 },
+      writable: true,
+    });
+
+    render(<BackButton />);
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(mockBack).toHaveBeenCalledTimes(1);
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  test('falls back to router.push("/") when history.length <= 1', () => {
+    Object.defineProperty(window, 'history', {
+      value: { length: 1 },
+      writable: true,
+    });
+
+    render(<BackButton />);
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(mockBack).not.toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith('/');
+  });
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+```bash
+pnpm test -- --testPathPattern=BackButton.test.tsx
+```
+
+Expected: FAIL with `BackButton` not found 或相关导入错误。
+
+- [ ] **Step 3: 实现组件**
+
+`src/components/BackButton.tsx`:
+
+```tsx
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+export function BackButton() {
+  const router = useRouter();
+
+  const handleClick = () => {
+    if (window.history.length > 1) {
+      router.back();
+    } else {
+      router.push('/');
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className="text-text-sub hover:text-text-main transition-colors"
+      aria-label="返回"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="20"
+        height="20"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="m15 18-6-6 6-6" />
+      </svg>
+    </button>
+  );
+}
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+```bash
+pnpm test -- --testPathPattern=BackButton.test.tsx
+```
+
+Expected: PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/BackButton.tsx src/components/__tests__/BackButton.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(components): BackButton 返回组件 + fallback 逻辑(Issue #7)
+EOF
+)"
+```
+
+---
+
+## Task 4: 创建 `DiaryTimeline` 组件 + 测试
+
+**Files:**
+- Create: `src/components/DiaryTimeline.tsx`
+- Create: `src/components/__tests__/DiaryTimeline.test.tsx`
+
+**目标:** Server Component，接收按月分组的日记数据，渲染 sticky 月份标签 + 竖向时间轴 + 日期标题列表。空标题时显示默认标题格式。
+
+- [ ] **Step 1: 写测试**
+
+`src/components/__tests__/DiaryTimeline.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { DiaryTimeline } from '../DiaryTimeline';
+import type { DiaryEntry, DiaryImage } from '@prisma/client';
+
+type Entry = DiaryEntry & { images: DiaryImage[] };
+
+function makeEntry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    id: overrides.id ?? 'id1',
+    date: overrides.date ?? new Date('2025-01-15'),
+    title: overrides.title ?? 'Test Title',
+    content: overrides.content ?? 'content',
+    mood: overrides.mood ?? 'sweet',
+    weather: overrides.weather ?? null,
+    createdAt: overrides.createdAt ?? new Date(),
+    updatedAt: overrides.updatedAt ?? new Date(),
+    images: overrides.images ?? [],
+  } as Entry;
+}
+
+describe('DiaryTimeline', () => {
+  test('renders empty state', () => {
+    render(<DiaryTimeline groups={new Map()} />);
+    expect(screen.getByText('还没有日记呢，翻开第一页吧')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /写下第一篇/i })).toBeInTheDocument();
+  });
+
+  test('renders single month with single entry', () => {
+    const groups = new Map<string, Entry[]>();
+    groups.set('2025-01', [makeEntry({ id: 'e1', date: new Date('2025-01-15'), title: '初次见面' })]);
+
+    render(<DiaryTimeline groups={groups} />);
+    expect(screen.getByText('2025 年 1 月')).toBeInTheDocument();
+    expect(screen.getByText('1月15日 周三')).toBeInTheDocument();
+    expect(screen.getByText('初次见面')).toBeInTheDocument();
+  });
+
+  test('renders default title when title is empty', () => {
+    const groups = new Map<string, Entry[]>();
+    groups.set('2025-01', [makeEntry({ id: 'e1', date: new Date('2025-01-15'), title: '' })]);
+
+    render(<DiaryTimeline groups={groups} />);
+    expect(screen.getByText('2025年1月15日 的心情')).toBeInTheDocument();
+  });
+
+  test('renders multiple months in order', () => {
+    const groups = new Map<string, Entry[]>();
+    groups.set('2025-02', [makeEntry({ id: 'e2', date: new Date('2025-02-10'), title: '二月' })]);
+    groups.set('2025-01', [makeEntry({ id: 'e1', date: new Date('2025-01-05'), title: '一月' })]);
+
+    render(<DiaryTimeline groups={groups} />);
+    const months = screen.getAllByRole('heading', { level: 2 });
+    expect(months[0]).toHaveTextContent('2025 年 2 月');
+    expect(months[1]).toHaveTextContent('2025 年 1 月');
+  });
+
+  test('renders multiple entries within same month', () => {
+    const groups = new Map<string, Entry[]>();
+    groups.set('2025-01', [
+      makeEntry({ id: 'e1', date: new Date('2025-01-20'), title: 'A' }),
+      makeEntry({ id: 'e2', date: new Date('2025-01-10'), title: 'B' }),
+    ]);
+
+    render(<DiaryTimeline groups={groups} />);
+    expect(screen.getByText('A')).toBeInTheDocument();
+    expect(screen.getByText('B')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+```bash
+pnpm test -- --testPathPattern=DiaryTimeline.test.tsx
+```
+
+Expected: FAIL with `DiaryTimeline` not found。
+
+- [ ] **Step 3: 实现组件**
+
+`src/components/DiaryTimeline.tsx`:
+
+```tsx
+import Link from 'next/link';
+import type { DiaryEntry, DiaryImage } from '@prisma/client';
+import { Button } from 'animal-island-ui';
+import dayjs from '@/lib/dayjs';
+
+interface DiaryTimelineProps {
+  groups: Map<string, Array<DiaryEntry & { images: DiaryImage[] }>>;
+}
+
+function formatMonthLabel(key: string): string {
+  const [year, month] = key.split('-');
+  return `${year} 年 ${parseInt(month, 10)} 月`;
+}
+
+function formatDate(date: Date): string {
+  return dayjs(date).format('M月D日 dddd');
+}
+
+function defaultTitle(date: Date): string {
+  return `${dayjs(date).format('YYYY年M月D日')} 的心情`;
+}
+
+export function DiaryTimeline({ groups }: DiaryTimelineProps) {
+  if (groups.size === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20 text-center">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="30"
+          height="30"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="text-text-sub"
+        >
+          <path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20" />
+        </svg>
+        <p className="mt-4 text-text-sub">还没有日记呢，翻开第一页吧</p>
+        <Link href="/diary/new" className="mt-6">
+          <Button type="primary">写下第一篇</Button>
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {Array.from(groups.entries()).map(([monthKey, entries]) => (
+        <section key={monthKey} className="relative pl-6">
+          <h2 className="sticky top-0 bg-cream/95 backdrop-blur z-10 py-2 text-sm font-bold text-text-main">
+            {formatMonthLabel(monthKey)}
+          </h2>
+          <div className="absolute left-[7px] top-10 bottom-0 w-px bg-border-soft" />
+          <ul className="space-y-3 py-2">
+            {entries.map((entry) => {
+              const title = entry.title || defaultTitle(entry.date);
+              return (
+                <li key={entry.id} className="relative">
+                  <span className="absolute left-[-22px] top-2 w-3 h-3 rounded-full bg-primary" />
+                  <Link
+                    href={`/diary/${entry.id}`}
+                    className="block hover:bg-card/60 rounded-lg p-2 -m-2 transition-colors"
+                  >
+                    <div className="text-xs text-text-sub">{formatDate(entry.date)}</div>
+                    <div className="text-base text-text-main">{title}</div>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+```bash
+pnpm test -- --testPathPattern=DiaryTimeline.test.tsx
+```
+
+Expected: PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/DiaryTimeline.tsx src/components/__tests__/DiaryTimeline.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(components): DiaryTimeline 时间轴列表组件(Issue #7)
+
+包含 sticky 月份标签、竖线时间轴、空状态 CTA。
+EOF
+)"
+```
+
+---
+
+## Task 5: 创建 `/diary` 页面
+
+**Files:**
+- Create: `src/app/diary/page.tsx`
+
+**目标:** Server Component，获取日记列表、按月分组、渲染顶部栏 + `DiaryTimeline`。空数组走空状态分支，不抛 `notFound()`。
+
+- [ ] **Step 1: 创建文件**
+
+```tsx
+import type { Metadata } from 'next';
+import { getDiaryList } from '@/lib/actions';
+import { DiaryTimeline } from '@/components/DiaryTimeline';
+import { BackButton } from '@/components/BackButton';
+import dayjs from '@/lib/dayjs';
+import type { DiaryEntry, DiaryImage } from '@prisma/client';
+
+export const metadata: Metadata = {
+  title: '目录',
+};
+
+type Entry = DiaryEntry & { images: DiaryImage[] };
+
+function groupByMonth(entries: Entry[]) {
+  const groups = new Map<string, Entry[]>();
+  for (const entry of entries) {
+    const key = dayjs(entry.date).format('YYYY-MM');
+    const arr = groups.get(key);
+    if (arr) {
+      arr.push(entry);
+    } else {
+      groups.set(key, [entry]);
+    }
+  }
+  return groups;
+}
+
+export default async function DiaryPage() {
+  const entries = await getDiaryList();
+  const groups = groupByMonth(entries);
+
+  return (
+    <main className="min-h-screen bg-cream">
+      <div className="max-w-[480px] mx-auto px-4 py-6">
+        <div className="flex items-center gap-4 mb-6">
+          <BackButton />
+          <h1 className="text-lg font-bold text-text-main">目录</h1>
+        </div>
+        <DiaryTimeline groups={groups} />
+      </div>
+    </main>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/app/diary/page.tsx
+git commit -m "$(cat <<'EOF'
+feat(page): /diary 时间线目录页(Issue #7)
+EOF
+)"
+```
+
+---
+
+## Task 6: 单篇页追加"时间线"入口
+
+**Files:**
+- Modify: `src/app/diary/[id]/page.tsx`
+
+**目标:** 在内容卡片下方追加"时间线"链接，纯 `<Link>`，不修改 `DiaryDetail`。
+
+- [ ] **Step 1: 在 `src/app/diary/[id]/page.tsx` 中修改**
+
+找到现有内容卡片的闭合 `</div>`（当前为 line 57 `<DiaryDetail entry={entry} />` 所在 div），在其后追加：
+
+```tsx
+        <div className="mt-6 flex justify-center">
+          <Link
+            href="/diary"
+            className="inline-flex items-center gap-2 text-sm text-text-sub hover:text-text-main transition-colors"
+            aria-label="返回时间线"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <line x1="21" y1="10" x2="3" y2="10" />
+              <line x1="21" y1="6" x2="3" y2="6" />
+              <line x1="21" y1="14" x2="3" y2="14" />
+              <line x1="21" y1="18" x2="3" y2="18" />
+            </svg>
+            时间线
+          </Link>
+        </div>
+```
+
+修改后的文件结构应为：
+
+```tsx
+// ... imports and page component up to return
+    <main className="min-h-screen bg-cream">
+      <div className="max-w-[480px] mx-auto px-4 py-6">
+        <div className="flex items-center gap-4 mb-6">
+          {/* existing back arrow + title */}
+        </div>
+        <div className="bg-card rounded-2xl p-4 shadow-sm">
+          <DiaryDetail entry={entry} />
+        </div>
+        <div className="mt-6 flex justify-center">
+          <Link ...>时间线</Link>
+        </div>
+      </div>
+    </main>
+// ...
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/app/diary/[id]/page.tsx
+git commit -m "$(cat <<'EOF'
+feat(page): /diary/[id] 底部追加时间线入口(Issue #7)
+EOF
+)"
+```
+
+---
+
+## Task 7: 运行全量测试 + 手动 e2e 自测
+
+**Files:**
+- 无新增文件，仅验证。
+
+**目标:** 确保自动化测试全绿，并完成设计文档中的边界自测清单。
+
+- [ ] **Step 1: 运行全量测试**
+
+```bash
+pnpm test
+```
+
+Expected: 全部通过。
+
+- [ ] **Step 2: 手动 e2e 自测清单**
+
+在本地启动开发服务器验证以下场景：
+
+```bash
+pnpm dev
+```
+
+逐项检查：
+- [ ] `0 篇日记` → 访问 `/diary`，空状态显示"还没有日记呢，翻开第一页吧"，CTA 按钮可跳转 `/diary/new`
+- [ ] `1 篇日记` → 单条显示，单组月份标签，无视觉异常
+- [ ] `同日 3 篇` → 创建 3 篇同日日记，目录内按创建时间倒序排列
+- [ ] `跨年`（如 2025-12 + 2026-01）→ 月份分组按时间倒序正确切换，标签包含年份
+- [ ] `空标题` → 显示默认标题 `${YYYY年M月D日} 的心情`
+- [ ] `sticky 月份标签` → 滚动时当前月份标签吸顶，切换平滑无闪烁
+- [ ] `直接访问 /diary 无来源` → 顶部返回按钮 fallback 到 `/`
+- [ ] `从 /diary/[id] 进入 /diary` → 顶部返回按钮回到该日记页
+- [ ] `/diary/[id]` 底部"时间线"入口可点击进入 `/diary`
+- [ ] `移动端宽度 < 480px` → 布局正确，无横向滚动条
+- [ ] `prefers-reduced-motion` → 无动画（本次基本无动画，自然满足）
+
+- [ ] **Step 3: Commit 自测完成标记（可选）**
+
+若自测全部通过，无需额外 commit；如有修复，按 `fix(...)` 单独提交。
+
+---
+
+## Self-Review Checklist
+
+### 1. Spec Coverage
+
+| Spec 要求 | 对应 Task |
+|-----------|-----------|
+| `getDiaryList` orderBy 改为 `[{ date: 'desc' }, { createdAt: 'desc' }]` | Task 1 |
+| 补充 actions 测试（同日多篇排序） | Task 1 |
+| 新增 `src/lib/dayjs.ts` 集中初始化 locale | Task 2 |
+| `BackButton` Client Component + `router.back()` + fallback `/` | Task 3 |
+| `BackButton` 测试（history.length 分支） | Task 3 |
+| `DiaryTimeline` sticky 月份标签 + 竖线 + 圆点 | Task 4 |
+| `DiaryTimeline` 空状态 CTA 跳转 `/diary/new` | Task 4 |
+| `DiaryTimeline` 测试（空数据、单篇、多篇、跨月、默认标题） | Task 4 |
+| `/diary` Server Component + 按月分组 Map | Task 5 |
+| `/diary/[id]` 底部"时间线"入口 | Task 6 |
+| 全量测试 + e2e 自测清单 | Task 7 |
+
+**无遗漏。**
+
+### 2. Placeholder Scan
+
+- 无 "TBD"、"TODO"、"implement later"。
+- 无 "Add appropriate error handling" 等模糊描述。
+- 每个测试都包含完整断言代码。
+- 每个 commit 命令包含完整 message。
+
+### 3. Type Consistency
+
+- `getDiaryList` 返回类型不变（Prisma 推断），调用方无需调整。
+- `DiaryTimeline` 的 `groups` prop 使用 `Map<string, Array<DiaryEntry & { images: DiaryImage[] }>>`，与 `getDiaryList` 返回结构一致。
+- `defaultTitle` 格式与 `DiaryDetail.tsx:19` 保持一致（`YYYY年M月D日 的心情`）。
+- `formatDate` 使用 `M月D日 dddd`，与 spec 要求的 `M月D日 周X` 一致（dayjs zh-cn locale 下 `dddd` 输出"周一"等）。
+
+---

--- a/docs/superpowers/specs/2026-05-03-diary-timeline-design.md
+++ b/docs/superpowers/specs/2026-05-03-diary-timeline-design.md
@@ -1,0 +1,288 @@
+# 时间线目录页 — 设计文档
+
+## 来源
+
+- Issue #7: `[M2] 时间线目录页：竖向时间轴 + 日记列表 + 快速跳转`
+- 主设计文档: `docs/superpowers/specs/2026-04-30-love-diary-design.md` 第 4.5 节
+- 设计决策会议: 2026-05-03
+
+## 背景与目标
+
+时间线目录页 `/diary` 作为辅助导航工具，让用户可以快速定位到任意一天的日记。它从单篇日记页通过"时间线"按钮进入，不作为主导航。第一版重在"快速找到那天的回忆"，不追求高级筛选与搜索能力。
+
+## 关键决策
+
+1. **本 issue 顺手把入口也做了**：在 `/diary/[id]` 单篇日记页底部加"时间线"链接，否则做完目录页用户进不去。
+2. **按月分组 + sticky 月份标签**：纯线性时间轴在数据量增长后难以快速定位，按月分组提供"记忆坐标"。
+3. **空状态带 CTA 跳转 `/diary/new`**：让首次访问空目录的用户有出路，不是死胡同。
+4. **数据复用现有 `getDiaryList()`**：当前数据量小，无需新建轻量 Server Action。
+5. **同日多篇排序对齐 `getDiaryNeighbors`**：把 `getDiaryList` 的 `orderBy` 扩展为 `[{ date: 'desc' }, { createdAt: 'desc' }]`，保证目录顺序与翻页顺序一致。
+6. **Server-first 实现**：除返回按钮外，整页 Server 渲染。当前无页内交互需求，避免过度 client 化。
+7. **返回按钮使用 `router.back()` + fallback `/`**：满足 issue "回到上一页或封面"的语义。
+
+## 页面路由
+
+| 路由 | 用途 | 类型 | 本次操作 |
+|------|------|------|----------|
+| `/diary` | 时间线目录页 | Server Component | **新增** |
+| `/diary/[id]` | 单篇日记详情页 | Server Component | **追加底部"时间线"入口** |
+
+## 新增/修改文件清单
+
+### 新增
+
+| 文件 | 类型 | 职责 |
+|------|------|------|
+| `src/app/diary/page.tsx` | Server Component | 数据获取、按月分组、传给 `DiaryTimeline` 渲染、空状态分支 |
+| `src/components/DiaryTimeline.tsx` | Server Component | 纯渲染：sticky 月份标签 + 圆点 + 日期 + 标题列表 |
+| `src/components/BackButton.tsx` | Client Component | `router.back()` + fallback `/`，复用给目录页顶部 |
+| `src/lib/dayjs.ts` | 模块 | 集中初始化 `dayjs`：`dayjs.locale('zh-cn')`，输出已配置好的 `dayjs` |
+
+### 修改
+
+| 文件 | 改动 |
+|------|------|
+| `src/lib/actions.ts` | `getDiaryList` 的 `orderBy` 改为 `[{ date: 'desc' }, { createdAt: 'desc' }]` |
+| `src/app/diary/[id]/page.tsx` | 在内容卡片下方追加"时间线"链接(纯 `<Link>` 即可) |
+
+## 数据获取与排序
+
+### `getDiaryList` 调整
+
+```typescript
+// 修改前
+export async function getDiaryList() {
+  return prisma.diaryEntry.findMany({
+    orderBy: { date: 'desc' },
+    include: { images: true },
+  });
+}
+
+// 修改后
+export async function getDiaryList() {
+  return prisma.diaryEntry.findMany({
+    orderBy: [{ date: 'desc' }, { createdAt: 'desc' }],
+    include: { images: true },
+  });
+}
+```
+
+封面页 `(protected)/page.tsx` 也调用 `getDiaryList()` 取 `[0]` 作为最新日记，二级排序键不影响其行为(同日多篇时取最新创建那一篇，更符合"最新"语义)。
+
+### 按月分组
+
+在 `/diary/page.tsx` Server 端用 `Map` 保留插入顺序：
+
+```typescript
+const groupByMonth = (entries: DiaryEntry[]) => {
+  const groups = new Map<string, DiaryEntry[]>();
+  for (const entry of entries) {
+    const key = dayjs(entry.date).format('YYYY-MM');
+    const arr = groups.get(key);
+    if (arr) arr.push(entry);
+    else groups.set(key, [entry]);
+  }
+  return groups;
+};
+```
+
+由于 `entries` 已按 `[date desc, createdAt desc]` 排序，`Map` 中月份键自然按时间倒序排列，组内顺序也正确。
+
+## UI 布局
+
+### 整体结构
+
+```
+┌─────────────────────────────────┐
+│ ←  目录                         │  顶部栏，固定高度，flex 居左
+├─────────────────────────────────┤
+│ ┌─ 2026 年 5 月 ───── sticky    │  月份标签，sticky top-0，半透明背景 + backdrop-blur
+│ │                                │
+│ ●─── 5月3日 周一  我们去了海边  │  时间轴项：圆点 + 日期 + 标题
+│ │                                │
+│ ●─── 5月1日 周六  今天的心情     │
+│ │                                │
+│ ┌─ 2026 年 4 月 ───── sticky    │
+│ │                                │
+│ ●─── 4月28日 周二 一起做的蛋糕   │
+└─────────────────────────────────┘
+```
+
+### 容器与排版
+
+- 外层 `<main className="min-h-screen bg-cream">`
+- 内容 `<div className="max-w-[480px] mx-auto px-4 py-6">`
+- 顶部栏与新增页保持一致：`flex items-center gap-4 mb-6` + `BackButton` + `<h1>目录</h1>`
+
+### 时间轴绘制
+
+每个月份分组的内部结构：
+
+```tsx
+<section className="relative pl-6">
+  <h2 className="sticky top-0 bg-cream/95 backdrop-blur z-10 py-2 text-sm font-bold text-text-main">
+    2026 年 5 月
+  </h2>
+  {/* 竖线（绝对定位贯穿整组） */}
+  <div className="absolute left-[7px] top-10 bottom-0 w-px bg-border-soft" />
+  <ul className="space-y-3 py-2">
+    {entries.map((entry) => (
+      <li key={entry.id} className="relative">
+        <span className="absolute left-[-22px] top-2 w-3 h-3 rounded-full bg-primary" />
+        <Link href={`/diary/${entry.id}`} className="block hover:bg-card/60 rounded-lg p-2 -m-2 transition-colors">
+          <div className="text-xs text-text-sub">5月3日 周一</div>
+          <div className="text-base text-text-main">我们去了海边</div>
+        </Link>
+      </li>
+    ))}
+  </ul>
+</section>
+```
+
+> 圆点定位：列表项 `pl-6`(24px)预留空间，竖线 `left-[7px]`(8px 左缘 + 7px = 15px ≈ 圆点中心)，圆点 `left-[-22px]`(从 li 内文起算往左 22px)对齐。具体像素在实现时按视觉微调。
+
+### 空状态
+
+```tsx
+<div className="flex flex-col items-center justify-center py-20 text-center">
+  <svg /* 简笔本/书本占位插画，30x30 */ />
+  <p className="mt-4 text-text-sub">还没有日记呢，翻开第一页吧</p>
+  <Link href="/diary/new" className="mt-6">
+    <Button type="primary">写下第一篇</Button>
+  </Link>
+</div>
+```
+
+> `animal-island-ui` 的 `Button` 是纯 `<button>` 元素，没有 `href` prop（见 `node_modules/animal-island-ui/dist/types/components/Button/Button.d.ts`）。用 `<Link>` 包裹即可。
+
+### 单篇页时间线入口
+
+在 `src/app/diary/[id]/page.tsx` 的 `<div className="bg-card rounded-2xl p-4 shadow-sm">` 下方追加：
+
+```tsx
+<div className="mt-6 flex justify-center">
+  <Link
+    href="/diary"
+    className="inline-flex items-center gap-2 text-sm text-text-sub hover:text-text-main transition-colors"
+    aria-label="返回时间线"
+  >
+    <svg /* 三横线时间轴 SVG，14x14 */ />
+    时间线
+  </Link>
+</div>
+```
+
+不修改 `DiaryDetail.tsx`，本入口只属于路由层。
+
+## 视觉与文案默认值
+
+| 项 | 值 |
+|----|----|
+| 顶部标题 | `目录` |
+| 日期格式 | `M月D日 周X`(`dayjs` zh-cn locale，例如 `5月3日 周一`) |
+| 月份标签格式 | `YYYY 年 M 月`(例如 `2026 年 5 月`) |
+| 默认标题 | `${YYYY年M月D日} 的心情`(沿用 `DiaryDetail.tsx:19`) |
+| 空状态文案 | `还没有日记呢，翻开第一页吧` |
+| 空状态 CTA 文字 | `写下第一篇` |
+| 时间线竖线粗细 | 1px |
+| 时间线竖线颜色 | `--color-border-soft` (#F1E4DD) |
+| 圆点尺寸 | 12px (w-3 h-3) |
+| 圆点颜色 | `--color-primary` (#F7C8D0) |
+| 月份标签字号 | `text-sm font-bold` |
+| 月份标签颜色 | `text-text-main` (#5B4B49) |
+| 月份标签背景 | `bg-cream/95 backdrop-blur` |
+| 日期文字 | `text-xs text-text-sub` (#8A7C78) |
+| 标题文字 | `text-base text-text-main` (#5B4B49) |
+| 列表项 hover | `hover:bg-card/60` |
+
+## dayjs 中文 locale 初始化
+
+新增 `src/lib/dayjs.ts`：
+
+```typescript
+import dayjs from 'dayjs';
+import 'dayjs/locale/zh-cn';
+
+dayjs.locale('zh-cn');
+
+export default dayjs;
+```
+
+需要中文星期的页面(本次新增的目录页)从 `@/lib/dayjs` 引入。其他既有页面(`(protected)/page.tsx`、`DiaryDetail.tsx` 等)目前直接 `import dayjs from 'dayjs'` 用法不变——现有页面没有用到中文 weekday，也不会被影响。
+
+## 数据流
+
+```
+URL /diary
+  ↓
+src/app/diary/page.tsx (Server Component)
+  ↓
+getDiaryList()  →  Prisma  →  SQLite
+  ↓
+按 YYYY-MM 分组成 Map
+  ↓
+传给 <DiaryTimeline groups={...} />
+  ↓
+渲染 sticky 月份标签 + 时间轴列表
+```
+
+## 错误处理
+
+- **DB 异常**：交给现有 `src/app/error.tsx` 错误边界，无需新增本页 error.tsx。
+- **空数组**：正常分支，渲染空状态，不抛 `notFound()`。
+- **无效 entry.date**：理论上数据库已校验，不再防御。
+- **直接访问 `/diary` 无来源**：`BackButton` 检测 `window.history.length <= 1` 时 `router.push('/')` 而非 `router.back()`。
+
+## 测试策略
+
+### 新增测试
+
+| 测试目标 | 位置 | 覆盖 |
+|----------|------|------|
+| `DiaryTimeline` 渲染 | `src/components/__tests__/DiaryTimeline.test.tsx` | 空数据、单篇、多篇、跨月、默认标题 |
+| `BackButton` fallback | `src/components/__tests__/BackButton.test.tsx` | history.length > 1 调 back，否则 push('/') |
+
+### 已有测试沿用
+
+- `src/lib/__tests__/actions.test.ts` 中已有 `getDiaryList` 测试。本次需要**新增/修改**一个用例验证：同日多篇按 `createdAt desc` 二级排序。
+- 其余 actions 测试不动。
+
+### 边界情况自测清单
+
+- [ ] 0 篇日记 → 空状态显示，CTA 跳 `/diary/new`
+- [ ] 1 篇日记 → 单条显示，单组月份标签，无视觉异常
+- [ ] 同日 3 篇 → 按 `createdAt desc` 内部排序
+- [ ] 跨年(如 2025-12 + 2026-01) → 月份分组按时间倒序正确切换，月份标签包含年份
+- [ ] 空标题 → 显示默认标题 `${YYYY年M月D日} 的心情`
+- [ ] sticky 月份标签滚动正确替换且不闪烁
+- [ ] 直接访问 `/diary` URL 无来源 → 返回按钮 fallback 到 `/`
+- [ ] 从 `/diary/[id]` 进入 → 返回回到该日记页
+- [ ] `/diary/[id]` 底部"时间线"入口可点击进入 `/diary`
+- [ ] 移动端宽度 < 480px 布局正确
+- [ ] `prefers-reduced-motion` 下无动画(本次基本无动画，自然满足)
+
+## 不包含范围
+
+- 按月份/年份**筛选**(P2，与按月分组不是一回事)
+- 搜索(P2)
+- 日历视图(Issue #13)
+- 分页 / 虚拟滚动(数据量小，暂不处理；当数据 > 200 条再考虑)
+- 编辑/删除日记(Issue #9)
+- 翻书动画(Issue #8)
+- 多人头像/合作者标记
+- 列表项的图片缩略图(目录追求简洁)
+
+## 依赖
+
+- `animal-island-ui`(`Button` 用于空状态 CTA)
+- `dayjs` + `dayjs/locale/zh-cn`(项目已安装 `dayjs`，locale 文件随包发布无需新装)
+- `next/link`(已有)
+- `next/navigation`(已有)
+- 已有 Server Action：`getDiaryList`(将做小幅 `orderBy` 调整)
+
+## 风险与注意事项
+
+- **sticky 月份标签穿透**：当列表项 hover 背景色与 sticky 半透明背景叠加可能视觉怪异。已通过 `bg-cream/95 backdrop-blur` 和较高 `z-10` 缓解，开发时实际看一下。
+- **`dayjs` locale 全局副作用**：在 `lib/dayjs.ts` 中调用 `dayjs.locale('zh-cn')` 是全局设置。其他文件即使从 `dayjs` 直接 import，导入图加载顺序后也会受影响——这正是想要的，无副作用。
+- **`getDiaryList` 排序变更的回归**：封面页只取 `[0]`，二级排序键变化最多影响"同日多篇时取哪一篇为最新"，逻辑上更合理，不构成回归。actions 测试需要补一个用例显式验证。
+- **空状态 SVG**：暂用极简 SVG 占位，可在动画系统(Issue #11)统一时再替换为正式插画。

--- a/src/app/diary/[id]/page.tsx
+++ b/src/app/diary/[id]/page.tsx
@@ -56,6 +56,31 @@ export default async function DiaryDetailPage({
         <div className="bg-card rounded-2xl p-4 shadow-sm">
           <DiaryDetail entry={entry} />
         </div>
+        <div className="mt-6 flex justify-center">
+          <Link
+            href="/diary"
+            className="inline-flex items-center gap-2 text-sm text-text-sub hover:text-text-main transition-colors"
+            aria-label="返回时间线"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <line x1="21" y1="10" x2="3" y2="10" />
+              <line x1="21" y1="6" x2="3" y2="6" />
+              <line x1="21" y1="14" x2="3" y2="14" />
+              <line x1="21" y1="18" x2="3" y2="18" />
+            </svg>
+            时间线
+          </Link>
+        </div>
       </div>
     </main>
   );

--- a/src/app/diary/page.tsx
+++ b/src/app/diary/page.tsx
@@ -1,0 +1,43 @@
+import type { Metadata } from 'next';
+import { getDiaryList } from '@/lib/actions';
+import { DiaryTimeline } from '@/components/DiaryTimeline';
+import { BackButton } from '@/components/BackButton';
+import dayjs from '@/lib/dayjs';
+import type { DiaryEntry, DiaryImage } from '@prisma/client';
+
+export const metadata: Metadata = {
+  title: '目录',
+};
+
+type Entry = DiaryEntry & { images: DiaryImage[] };
+
+function groupByMonth(entries: Entry[]) {
+  const groups = new Map<string, Entry[]>();
+  for (const entry of entries) {
+    const key = dayjs(entry.date).format('YYYY-MM');
+    const arr = groups.get(key);
+    if (arr) {
+      arr.push(entry);
+    } else {
+      groups.set(key, [entry]);
+    }
+  }
+  return groups;
+}
+
+export default async function DiaryPage() {
+  const entries = await getDiaryList();
+  const groups = groupByMonth(entries);
+
+  return (
+    <main className="min-h-screen bg-cream">
+      <div className="max-w-[480px] mx-auto px-4 py-6">
+        <div className="flex items-center gap-4 mb-6">
+          <BackButton />
+          <h1 className="text-lg font-bold text-text-main">目录</h1>
+        </div>
+        <DiaryTimeline groups={groups} />
+      </div>
+    </main>
+  );
+}

--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+export function BackButton() {
+  const router = useRouter();
+
+  const handleClick = () => {
+    if (window.history.length > 1) {
+      router.back();
+    } else {
+      router.push('/');
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className="text-text-sub hover:text-text-main transition-colors"
+      aria-label="返回"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="20"
+        height="20"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="m15 18-6-6 6-6" />
+      </svg>
+    </button>
+  );
+}

--- a/src/components/DiaryTimeline.tsx
+++ b/src/components/DiaryTimeline.tsx
@@ -45,7 +45,10 @@ export function DiaryTimeline({ groups }: DiaryTimelineProps) {
       {Array.from(groups.entries()).map(([monthKey, entries]) => (
         <section key={monthKey} className="relative pl-6">
           <h2 className="sticky top-0 bg-cream/95 backdrop-blur z-10 py-2 text-sm font-bold text-text-main">
-            {dayjs(monthKey).format('YYYY年M月')}
+            {(() => {
+              const [year, month] = monthKey.split('-');
+              return `${year} 年 ${parseInt(month, 10)} 月`;
+            })()}
           </h2>
           <div className="absolute left-[7px] top-10 bottom-0 w-px bg-border-soft" />
           <ul className="space-y-3 py-2">

--- a/src/components/DiaryTimeline.tsx
+++ b/src/components/DiaryTimeline.tsx
@@ -1,0 +1,73 @@
+import Link from 'next/link';
+import { Button } from 'animal-island-ui';
+import dayjs from '@/lib/dayjs';
+import type { DiaryEntry, DiaryImage } from '@prisma/client';
+
+interface DiaryTimelineProps {
+  groups: Map<string, Array<DiaryEntry & { images: DiaryImage[] }>>;
+}
+
+function defaultTitle(date: Date): string {
+  return `${dayjs(date).format('YYYY年M月D日')} 的心情`;
+}
+
+export function DiaryTimeline({ groups }: DiaryTimelineProps) {
+  if (groups.size === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20 text-center">
+        <svg
+          width="30"
+          height="30"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="text-text-sub"
+        >
+          <path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20" />
+        </svg>
+        <p className="mt-3 text-sm text-text-sub">
+          还没有日记呢，翻开第一页吧
+        </p>
+        <div className="mt-4">
+          <Link href="/diary/new">
+            <Button type="primary">写下第一篇</Button>
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {Array.from(groups.entries()).map(([monthKey, entries]) => (
+        <section key={monthKey} className="relative pl-6">
+          <h2 className="sticky top-0 bg-cream/95 backdrop-blur z-10 py-2 text-sm font-bold text-text-main">
+            {dayjs(monthKey).format('YYYY年M月')}
+          </h2>
+          <div className="absolute left-[7px] top-10 bottom-0 w-px bg-border-soft" />
+          <ul className="space-y-3 py-2">
+            {entries.map((entry) => (
+              <li key={entry.id} className="relative">
+                <span className="absolute left-[-22px] top-2 w-3 h-3 rounded-full bg-primary" />
+                <Link
+                  href={`/diary/${entry.id}`}
+                  className="block hover:bg-card/60 rounded-lg p-2 -m-2 transition-colors"
+                >
+                  <div className="text-xs text-text-sub">
+                    {dayjs(entry.date).format('M月D日 dddd')}
+                  </div>
+                  <div className="text-base text-text-main">
+                    {entry.title || defaultTitle(entry.date)}
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/src/components/__tests__/BackButton.test.tsx
+++ b/src/components/__tests__/BackButton.test.tsx
@@ -15,6 +15,11 @@ describe('BackButton', () => {
   beforeEach(() => {
     mockBack.mockClear();
     mockPush.mockClear();
+    Object.defineProperty(window, 'history', {
+      value: { length: 1 },
+      writable: true,
+      configurable: true,
+    });
   });
 
   test('calls router.back when history.length > 1', () => {

--- a/src/components/__tests__/BackButton.test.tsx
+++ b/src/components/__tests__/BackButton.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BackButton } from '../BackButton';
+
+const mockBack = jest.fn();
+const mockPush = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    back: mockBack,
+    push: mockPush,
+  }),
+}));
+
+describe('BackButton', () => {
+  beforeEach(() => {
+    mockBack.mockClear();
+    mockPush.mockClear();
+  });
+
+  test('calls router.back when history.length > 1', () => {
+    Object.defineProperty(window, 'history', {
+      value: { length: 2 },
+      writable: true,
+    });
+
+    render(<BackButton />);
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(mockBack).toHaveBeenCalledTimes(1);
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  test('falls back to router.push("/") when history.length <= 1', () => {
+    Object.defineProperty(window, 'history', {
+      value: { length: 1 },
+      writable: true,
+    });
+
+    render(<BackButton />);
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(mockBack).not.toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith('/');
+  });
+});

--- a/src/components/__tests__/DiaryTimeline.test.tsx
+++ b/src/components/__tests__/DiaryTimeline.test.tsx
@@ -50,7 +50,7 @@ describe('DiaryTimeline', () => {
 
     render(<DiaryTimeline groups={groups} />);
 
-    expect(screen.getByRole('heading', { name: '2025年1月' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: '2025 年 1 月' })).toBeInTheDocument();
     expect(screen.getByText('1月15日 星期三')).toBeInTheDocument();
     expect(screen.getByText('Test Title')).toBeInTheDocument();
   });
@@ -74,8 +74,8 @@ describe('DiaryTimeline', () => {
     render(<DiaryTimeline groups={groups} />);
 
     const headings = screen.getAllByRole('heading');
-    expect(headings[0]).toHaveTextContent('2025年2月');
-    expect(headings[1]).toHaveTextContent('2025年1月');
+    expect(headings[0]).toHaveTextContent('2025 年 2 月');
+    expect(headings[1]).toHaveTextContent('2025 年 1 月');
   });
 
   test('renders multiple entries within same month', () => {

--- a/src/components/__tests__/DiaryTimeline.test.tsx
+++ b/src/components/__tests__/DiaryTimeline.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from '@testing-library/react';
+import { DiaryTimeline } from '../DiaryTimeline';
+import type { DiaryEntry, DiaryImage } from '@prisma/client';
+
+type Entry = DiaryEntry & { images: DiaryImage[] };
+
+function makeEntry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    id: overrides.id ?? 'id1',
+    date: overrides.date ?? new Date('2025-01-15'),
+    title: overrides.title ?? 'Test Title',
+    content: overrides.content ?? 'content',
+    mood: overrides.mood ?? 'sweet',
+    weather: overrides.weather ?? null,
+    createdAt: overrides.createdAt ?? new Date(),
+    updatedAt: overrides.updatedAt ?? new Date(),
+    images: overrides.images ?? [],
+  } as Entry;
+}
+
+jest.mock('next/link', () => {
+  return function MockLink({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) {
+    return <a href={href}>{children}</a>;
+  };
+});
+
+describe('DiaryTimeline', () => {
+  test('renders empty state', () => {
+    render(<DiaryTimeline groups={new Map()} />);
+
+    expect(
+      screen.getByText('还没有日记呢，翻开第一页吧')
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '写下第一篇' })).toHaveAttribute(
+      'href',
+      '/diary/new'
+    );
+  });
+
+  test('renders single month with single entry', () => {
+    const groups = new Map<string, Entry[]>([
+      ['2025-01', [makeEntry()]],
+    ]);
+
+    render(<DiaryTimeline groups={groups} />);
+
+    expect(screen.getByRole('heading', { name: '2025年1月' })).toBeInTheDocument();
+    expect(screen.getByText('1月15日 星期三')).toBeInTheDocument();
+    expect(screen.getByText('Test Title')).toBeInTheDocument();
+  });
+
+  test('renders default title when title is empty', () => {
+    const groups = new Map<string, Entry[]>([
+      ['2025-01', [makeEntry({ title: '' })]],
+    ]);
+
+    render(<DiaryTimeline groups={groups} />);
+
+    expect(screen.getByText('2025年1月15日 的心情')).toBeInTheDocument();
+  });
+
+  test('renders multiple months in order', () => {
+    const groups = new Map<string, Entry[]>([
+      ['2025-02', [makeEntry({ id: 'id2', date: new Date('2025-02-10') })]],
+      ['2025-01', [makeEntry()]],
+    ]);
+
+    render(<DiaryTimeline groups={groups} />);
+
+    const headings = screen.getAllByRole('heading');
+    expect(headings[0]).toHaveTextContent('2025年2月');
+    expect(headings[1]).toHaveTextContent('2025年1月');
+  });
+
+  test('renders multiple entries within same month', () => {
+    const groups = new Map<string, Entry[]>([
+      [
+        '2025-01',
+        [
+          makeEntry({ id: 'id1', title: 'First Entry' }),
+          makeEntry({ id: 'id2', title: 'Second Entry', date: new Date('2025-01-20') }),
+        ],
+      ],
+    ]);
+
+    render(<DiaryTimeline groups={groups} />);
+
+    expect(screen.getByText('First Entry')).toBeInTheDocument();
+    expect(screen.getByText('Second Entry')).toBeInTheDocument();
+  });
+});

--- a/src/lib/__tests__/actions.test.ts
+++ b/src/lib/__tests__/actions.test.ts
@@ -72,6 +72,21 @@ describe('Diary Actions', () => {
     expect(list[2].title).toBe('A');
   });
 
+  test('getDiaryList sorts same-day entries by createdAt desc', async () => {
+    const sameDate = new Date('2025-01-15');
+    const first = await createDiary({ date: sameDate, title: 'First', content: 'a' });
+    const second = await createDiary({ date: sameDate, title: 'Second', content: 'b' });
+    const third = await createDiary({ date: sameDate, title: 'Third', content: 'c' });
+
+    const base = dayjs('2025-01-15T10:00:00.000Z');
+    await prisma.diaryEntry.update({ where: { id: first.id }, data: { createdAt: base.toDate() } });
+    await prisma.diaryEntry.update({ where: { id: second.id }, data: { createdAt: base.add(1, 'hour').toDate() } });
+    await prisma.diaryEntry.update({ where: { id: third.id }, data: { createdAt: base.add(2, 'hour').toDate() } });
+
+    const list = await getDiaryList();
+    expect(list.map((d) => d.title)).toEqual(['Third', 'Second', 'First']);
+  });
+
   test('updateDiary updates fields and images', async () => {
     const created = await createDiary({
       date: new Date('2025-01-15'),

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -40,7 +40,7 @@ export async function getDiaryById(id: string) {
 
 export async function getDiaryList() {
   return prisma.diaryEntry.findMany({
-    orderBy: { date: 'desc' },
+    orderBy: [{ date: 'desc' }, { createdAt: 'desc' }],
     include: { images: true },
   });
 }

--- a/src/lib/dayjs.ts
+++ b/src/lib/dayjs.ts
@@ -1,0 +1,6 @@
+import dayjs from 'dayjs';
+import 'dayjs/locale/zh-cn';
+
+dayjs.locale('zh-cn');
+
+export default dayjs;


### PR DESCRIPTION
## Summary
- 新增 `/diary` 时间线目录页：按月分组 + sticky 月份标签 + 竖向时间轴列表
- `/diary/[id]` 单篇页底部追加"时间线"入口链接
- `getDiaryList` 增加 `createdAt` 二级排序，保证目录顺序与翻页顺序一致
- 新增 `BackButton` 返回组件（router.back() + fallback 到 `/`）
- 新增 `DiaryTimeline` 时间轴渲染组件（Server Component）
- 集中初始化 `dayjs` 中文 locale

## Test Plan
- [x] `pnpm test` 全量通过（7 suites, 45 tests）
- [x] `pnpm build` 编译通过
- [x] 空状态渲染 + CTA 跳转 `/diary/new`
- [x] 单条/多条/跨月分组正确
- [x] 同日多篇按 `createdAt desc` 排序
- [x] 空标题显示默认标题格式
- [x] `/diary/[id]` 底部"时间线"入口可点击