### PR TITLE
[M2] 单篇日记页 + 翻书动画：上一篇/下一篇 + 左右滑动手势

### DIFF
--- a/docs/superpowers/plans/2026-05-04-diary-page-flip.md
+++ b/docs/superpowers/plans/2026-05-04-diary-page-flip.md
@@ -1,0 +1,883 @@
+# Issue #8：单篇日记页 + 翻书动画 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 实现单篇日记阅读页，支持上一篇/下一篇导航、3D 翻书动画、左右滑动手势。
+
+**Architecture:** Server Component 页面获取数据，Client Component `PageFlipWrapper` 管理翻书动画和手势。`DiaryNavigation` 处理底部导航按钮。动画完成后通过 `router.push` 导航到新 URL。
+
+**Tech Stack:** Next.js 16 App Router, React, TypeScript, Tailwind CSS v4, Framer Motion, Prisma + SQLite, Jest + React Testing Library
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/components/DiaryDetail.tsx` | Modify | 添加篇数序号展示 |
+| `src/components/PageFlipWrapper.tsx` | Create | 3D 翻书动画 + 手势检测 + 动画锁 |
+| `src/components/DiaryNavigation.tsx` | Create | 底部导航按钮（上一篇/下一篇/时间线） |
+| `src/app/diary/[id]/page.tsx` | Modify | 数据获取、篇数计算、组件整合 |
+| `src/components/__tests__/DiaryDetail.test.tsx` | Create | DiaryDetail 组件测试 |
+| `src/components/__tests__/DiaryNavigation.test.tsx` | Create | DiaryNavigation 组件测试 |
+| `src/components/__tests__/PageFlipWrapper.test.tsx` | Create | PageFlipWrapper 组件测试 |
+
+---
+
+## Helper: makeEntry
+
+测试文件中复用以下 helper：
+
+```typescript
+import type { DiaryEntry, DiaryImage } from '@prisma/client';
+
+type Entry = DiaryEntry & { images: DiaryImage[] };
+
+function makeEntry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    id: overrides.id ?? 'id1',
+    date: overrides.date ?? new Date('2025-01-15'),
+    title: overrides.title ?? 'Test Title',
+    content: overrides.content ?? 'content',
+    mood: overrides.mood ?? 'sweet',
+    weather: overrides.weather ?? null,
+    createdAt: overrides.createdAt ?? new Date(),
+    updatedAt: overrides.updatedAt ?? new Date(),
+    images: overrides.images ?? [],
+  } as Entry;
+}
+```
+
+---
+
+## Task 1: DiaryDetail 篇数序号
+
+**Files:**
+- Modify: `src/components/DiaryDetail.tsx`
+- Test: `src/components/__tests__/DiaryDetail.test.tsx`
+
+### Step 1: 写测试（先失败）
+
+创建 `src/components/__tests__/DiaryDetail.test.tsx`：
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { DiaryDetail } from '../DiaryDetail';
+import type { DiaryEntry, DiaryImage } from '@prisma/client';
+
+type Entry = DiaryEntry & { images: DiaryImage[] };
+
+function makeEntry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    id: overrides.id ?? 'id1',
+    date: overrides.date ?? new Date('2025-01-15'),
+    title: overrides.title ?? 'Test Title',
+    content: overrides.content ?? 'content',
+    mood: overrides.mood ?? 'sweet',
+    weather: overrides.weather ?? null,
+    createdAt: overrides.createdAt ?? new Date(),
+    updatedAt: overrides.updatedAt ?? new Date(),
+    images: overrides.images ?? [],
+  } as Entry;
+}
+
+describe('DiaryDetail', () => {
+  test('renders entry number when provided', () => {
+    render(<DiaryDetail entry={makeEntry()} entryNumber={12} />);
+    expect(screen.getByText('第 12 篇')).toBeInTheDocument();
+  });
+
+  test('does not render entry number when not provided', () => {
+    render(<DiaryDetail entry={makeEntry()} />);
+    expect(screen.queryByText(/第 \d+ 篇/)).not.toBeInTheDocument();
+  });
+
+  test('renders title and content', () => {
+    render(<DiaryDetail entry={makeEntry({ title: 'My Day', content: 'Had fun' })} />);
+    expect(screen.getByText('My Day')).toBeInTheDocument();
+    expect(screen.getByText('Had fun')).toBeInTheDocument();
+  });
+
+  test('renders fallback title when title is null', () => {
+    render(<DiaryDetail entry={makeEntry({ title: null })} />);
+    expect(screen.getByText('2025年1月15日 的心情')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `npx jest src/components/__tests__/DiaryDetail.test.tsx`
+Expected: FAIL — `entryNumber` prop 不存在
+
+- [ ] **Step 3: 修改 DiaryDetail 添加篇数序号**
+
+修改 `src/components/DiaryDetail.tsx`：
+
+```tsx
+interface DiaryDetailProps {
+  entry: DiaryEntry & { images: DiaryImage[] };
+  entryNumber?: number;
+}
+
+export function DiaryDetail({ entry, entryNumber }: DiaryDetailProps) {
+  // ... existing code ...
+
+  return (
+    <article className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2 text-sm text-text-sub">
+          <span>{dayjs(entry.date).format('YYYY年M月D日')}</span>
+          <span
+            className="flex items-center gap-1 px-2 py-0.5 rounded-full"
+            style={{ backgroundColor: mood.color + '33' }}
+          >
+            <span
+              className="w-2 h-2 rounded-full"
+              style={{ backgroundColor: mood.color }}
+            />
+            {mood.label}
+          </span>
+        </div>
+        {entryNumber !== undefined && (
+          <span className="text-sm text-text-sub">第 {entryNumber} 篇</span>
+        )}
+      </div>
+
+      <h1 className="text-xl font-bold text-text-main">{displayTitle}</h1>
+
+      <p className="text-base text-text-main whitespace-pre-wrap leading-relaxed">
+        {entry.content}
+      </p>
+
+      {/* images section remains unchanged */}
+    </article>
+  );
+}
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `npx jest src/components/__tests__/DiaryDetail.test.tsx`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/DiaryDetail.tsx src/components/__tests__/DiaryDetail.test.tsx
+git commit -m "feat(DiaryDetail): 添加篇数序号展示"
+```
+
+---
+
+## Task 2: DiaryNavigation 底部导航组件
+
+**Files:**
+- Create: `src/components/DiaryNavigation.tsx`
+- Test: `src/components/__tests__/DiaryNavigation.test.tsx`
+
+### Step 1: 写测试（先失败）
+
+创建 `src/components/__tests__/DiaryNavigation.test.tsx`：
+
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DiaryNavigation } from '../DiaryNavigation';
+
+const mockOnPrev = jest.fn();
+const mockOnNext = jest.fn();
+
+describe('DiaryNavigation', () => {
+  beforeEach(() => {
+    mockOnPrev.mockClear();
+    mockOnNext.mockClear();
+  });
+
+  test('renders all buttons when both neighbors exist', () => {
+    render(<DiaryNavigation prevId="prev1" nextId="next1" onPrev={mockOnPrev} onNext={mockOnNext} />);
+    expect(screen.getByRole('link', { name: /时间线/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /上一篇/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /下一篇/ })).toBeInTheDocument();
+  });
+
+  test('hides prev button when prevId is null', () => {
+    render(<DiaryNavigation prevId={null} nextId="next1" onPrev={mockOnPrev} onNext={mockOnNext} />);
+    expect(screen.queryByRole('button', { name: /上一篇/ })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /下一篇/ })).toBeInTheDocument();
+  });
+
+  test('hides next button when nextId is null', () => {
+    render(<DiaryNavigation prevId="prev1" nextId={null} onPrev={mockOnPrev} onNext={mockOnNext} />);
+    expect(screen.getByRole('button', { name: /上一篇/ })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /下一篇/ })).not.toBeInTheDocument();
+  });
+
+  test('hides both nav buttons when both ids are null', () => {
+    render(<DiaryNavigation prevId={null} nextId={null} onPrev={mockOnPrev} onNext={mockOnNext} />);
+    expect(screen.queryByRole('button', { name: /上一篇/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /下一篇/ })).not.toBeInTheDocument();
+  });
+
+  test('calls onPrev when prev button clicked', () => {
+    render(<DiaryNavigation prevId="prev1" nextId="next1" onPrev={mockOnPrev} onNext={mockOnNext} />);
+    fireEvent.click(screen.getByRole('button', { name: /上一篇/ }));
+    expect(mockOnPrev).toHaveBeenCalledTimes(1);
+  });
+
+  test('calls onNext when next button clicked', () => {
+    render(<DiaryNavigation prevId="prev1" nextId="next1" onPrev={mockOnPrev} onNext={mockOnNext} />);
+    fireEvent.click(screen.getByRole('button', { name: /下一篇/ }));
+    expect(mockOnNext).toHaveBeenCalledTimes(1);
+  });
+
+  test('timeline button links to /diary', () => {
+    render(<DiaryNavigation prevId="prev1" nextId="next1" onPrev={mockOnPrev} onNext={mockOnNext} />);
+    expect(screen.getByRole('link', { name: /时间线/ })).toHaveAttribute('href', '/diary');
+  });
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `npx jest src/components/__tests__/DiaryNavigation.test.tsx`
+Expected: FAIL — DiaryNavigation 组件不存在
+
+- [ ] **Step 3: 实现 DiaryNavigation 组件**
+
+创建 `src/components/DiaryNavigation.tsx`：
+
+```tsx
+'use client';
+
+import Link from 'next/link';
+
+interface DiaryNavigationProps {
+  prevId: string | null;
+  nextId: string | null;
+  onPrev: () => void;
+  onNext: () => void;
+}
+
+export function DiaryNavigation({ prevId, nextId, onPrev, onNext }: DiaryNavigationProps) {
+  return (
+    <div className="flex items-center justify-between mt-6">
+      <Link
+        href="/diary"
+        className="inline-flex items-center gap-1.5 text-sm text-text-sub hover:text-text-main transition-colors"
+        aria-label="时间线"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <line x1="21" y1="10" x2="3" y2="10" />
+          <line x1="21" y1="6" x2="3" y2="6" />
+          <line x1="21" y1="14" x2="3" y2="14" />
+          <line x1="21" y1="18" x2="3" y2="18" />
+        </svg>
+        时间线
+      </Link>
+
+      <div className="flex items-center gap-3">
+        {prevId && (
+          <button
+            type="button"
+            onClick={onPrev}
+            className="inline-flex items-center gap-1 px-3 py-1.5 text-sm text-text-sub hover:text-text-main bg-card border border-border-soft rounded-full transition-colors"
+            aria-label="上一篇"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="m15 18-6-6 6-6" />
+            </svg>
+            上一篇
+          </button>
+        )}
+        {nextId && (
+          <button
+            type="button"
+            onClick={onNext}
+            className="inline-flex items-center gap-1 px-3 py-1.5 text-sm text-text-sub hover:text-text-main bg-card border border-border-soft rounded-full transition-colors"
+            aria-label="下一篇"
+          >
+            下一篇
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="m9 18 6-6-6-6" />
+            </svg>
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `npx jest src/components/__tests__/DiaryNavigation.test.tsx`
+Expected: PASS (7 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/DiaryNavigation.tsx src/components/__tests__/DiaryNavigation.test.tsx
+git commit -m "feat(DiaryNavigation): 添加底部上一篇/下一篇/时间线导航"
+```
+
+---
+
+## Task 3: PageFlipWrapper 翻书动画组件
+
+**Files:**
+- Create: `src/components/PageFlipWrapper.tsx`
+- Test: `src/components/__tests__/PageFlipWrapper.test.tsx`
+
+### Step 1: 写测试（先失败）
+
+创建 `src/components/__tests__/PageFlipWrapper.test.tsx`：
+
+```tsx
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { PageFlipWrapper } from '../PageFlipWrapper';
+
+const mockPush = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+describe('PageFlipWrapper', () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+  });
+
+  test('renders children content', () => {
+    render(
+      <PageFlipWrapper prevId="prev1" nextId="next1" currentId="id1">
+        <div data-testid="content">Diary Content</div>
+      </PageFlipWrapper>
+    );
+    expect(screen.getByTestId('content')).toHaveTextContent('Diary Content');
+  });
+
+  test('calls router.push with prevId when prev button clicked', async () => {
+    render(
+      <PageFlipWrapper prevId="prev1" nextId="next1" currentId="id1">
+        <div>Content</div>
+      </PageFlipWrapper>
+    );
+    const prevBtn = screen.getByRole('button', { name: /上一篇/ });
+    fireEvent.click(prevBtn);
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/diary/prev1');
+    });
+  });
+
+  test('calls router.push with nextId when next button clicked', async () => {
+    render(
+      <PageFlipWrapper prevId="prev1" nextId="next1" currentId="id1">
+        <div>Content</div>
+      </PageFlipWrapper>
+    );
+    const nextBtn = screen.getByRole('button', { name: /下一篇/ });
+    fireEvent.click(nextBtn);
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/diary/next1');
+    });
+  });
+
+  test('hides prev button when prevId is null', () => {
+    render(
+      <PageFlipWrapper prevId={null} nextId="next1" currentId="id1">
+        <div>Content</div>
+      </PageFlipWrapper>
+    );
+    expect(screen.queryByRole('button', { name: /上一篇/ })).not.toBeInTheDocument();
+  });
+
+  test('hides next button when nextId is null', () => {
+    render(
+      <PageFlipWrapper prevId="prev1" nextId={null} currentId="id1">
+        <div>Content</div>
+      </PageFlipWrapper>
+    );
+    expect(screen.queryByRole('button', { name: /下一篇/ })).not.toBeInTheDocument();
+  });
+
+  test('hides both buttons when both are null', () => {
+    render(
+      <PageFlipWrapper prevId={null} nextId={null} currentId="id1">
+        <div>Content</div>
+      </PageFlipWrapper>
+    );
+    expect(screen.queryByRole('button', { name: /上一篇/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /下一篇/ })).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `npx jest src/components/__tests__/PageFlipWrapper.test.tsx`
+Expected: FAIL — PageFlipWrapper 组件不存在
+
+- [ ] **Step 3: 实现 PageFlipWrapper 组件**
+
+创建 `src/components/PageFlipWrapper.tsx`：
+
+```tsx
+'use client';
+
+import { useState, useRef, useCallback, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { motion, AnimatePresence } from 'framer-motion';
+import Link from 'next/link';
+
+type Direction = 'left' | 'right';
+
+interface PageFlipWrapperProps {
+  children: React.ReactNode;
+  prevId: string | null;
+  nextId: string | null;
+  currentId: string;
+}
+
+export function PageFlipWrapper({ children, prevId, nextId, currentId }: PageFlipWrapperProps) {
+  const router = useRouter();
+  const [direction, setDirection] = useState<Direction | null>(null);
+  const [isAnimating, setIsAnimating] = useState(false);
+  const touchStartX = useRef<number | null>(null);
+
+  const prefersReducedMotion =
+    typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  const navigate = useCallback(
+    (targetId: string, dir: Direction) => {
+      if (prefersReducedMotion) {
+        router.push(`/diary/${targetId}`);
+        return;
+      }
+      setDirection(dir);
+      setIsAnimating(true);
+    },
+    [router, prefersReducedMotion]
+  );
+
+  const handleAnimationComplete = useCallback(() => {
+    if (direction === 'left' && prevId) {
+      router.push(`/diary/${prevId}`);
+    } else if (direction === 'right' && nextId) {
+      router.push(`/diary/${nextId}`);
+    }
+    setIsAnimating(false);
+    setDirection(null);
+  }, [direction, prevId, nextId, router]);
+
+  const goToPrev = useCallback(() => {
+    if (isAnimating || !prevId) return;
+    navigate(prevId, 'left');
+  }, [isAnimating, prevId, navigate]);
+
+  const goToNext = useCallback(() => {
+    if (isAnimating || !nextId) return;
+    navigate(nextId, 'right');
+  }, [isAnimating, nextId, navigate]);
+
+  const handleTouchStart = useCallback(
+    (e: React.TouchEvent) => {
+      if (isAnimating) return;
+      touchStartX.current = e.touches[0].clientX;
+    },
+    [isAnimating]
+  );
+
+  const handleTouchEnd = useCallback(
+    (e: React.TouchEvent) => {
+      if (isAnimating || touchStartX.current === null) return;
+      const diff = e.changedTouches[0].clientX - touchStartX.current;
+      if (diff > 80) {
+        goToPrev();
+      } else if (diff < -80) {
+        goToNext();
+      }
+      touchStartX.current = null;
+    },
+    [isAnimating, goToPrev, goToNext]
+  );
+
+  const variants = {
+    enter: (dir: Direction | null) => ({
+      rotateY: dir === 'right' ? 90 : -90,
+      opacity: 0,
+      x: dir === 'right' ? '50%' : '-50%',
+    }),
+    center: {
+      rotateY: 0,
+      opacity: 1,
+      x: 0,
+    },
+    exit: (dir: Direction | null) => ({
+      rotateY: dir === 'right' ? -90 : 90,
+      opacity: 0,
+      x: dir === 'right' ? '-50%' : '50%',
+    }),
+  };
+
+  return (
+    <div
+      className="min-h-screen bg-cream"
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+    >
+      <div className="max-w-[480px] mx-auto px-4 py-6">
+        {/* 顶部导航 */}
+        <div className="flex items-center justify-between mb-6">
+          <Link
+            href="/"
+            className="inline-flex items-center gap-1 text-sm text-text-sub hover:text-text-main transition-colors"
+            aria-label="返回封面"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="m15 18-6-6 6-6" />
+            </svg>
+            封面
+          </Link>
+
+          <div className="flex items-center gap-3">
+            {prevId && (
+              <button
+                type="button"
+                onClick={goToPrev}
+                disabled={isAnimating}
+                className="text-text-sub hover:text-text-main transition-colors disabled:opacity-50"
+                aria-label="上一篇"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="m15 18-6-6 6-6" />
+                </svg>
+              </button>
+            )}
+            {nextId && (
+              <button
+                type="button"
+                onClick={goToNext}
+                disabled={isAnimating}
+                className="text-text-sub hover:text-text-main transition-colors disabled:opacity-50"
+                aria-label="下一篇"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="m9 18 6-6-6-6" />
+                </svg>
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* 3D 翻书容器 */}
+        <div
+          style={{
+            perspective: '1200px',
+            transformStyle: 'preserve-3d',
+          }}
+        >
+          <AnimatePresence mode="wait" initial={false}>
+            <motion.div
+              key={currentId}
+              custom={direction}
+              variants={variants}
+              initial="enter"
+              animate="center"
+              exit="exit"
+              transition={{ duration: 0.4, ease: 'easeInOut' }}
+              onAnimationComplete={handleAnimationComplete}
+              style={{
+                transformStyle: 'preserve-3d',
+                backfaceVisibility: 'hidden',
+              }}
+            >
+              <div className="bg-card rounded-2xl p-4 shadow-sm">
+                {children}
+              </div>
+            </motion.div>
+          </AnimatePresence>
+        </div>
+
+        {/* 底部导航 */}
+        <div className="mt-6 flex items-center justify-between">
+          <Link
+            href="/diary"
+            className="inline-flex items-center gap-1.5 text-sm text-text-sub hover:text-text-main transition-colors"
+            aria-label="时间线"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <line x1="21" y1="10" x2="3" y2="10" />
+              <line x1="21" y1="6" x2="3" y2="6" />
+              <line x1="21" y1="14" x2="3" y2="14" />
+              <line x1="21" y1="18" x2="3" y2="18" />
+            </svg>
+            时间线
+          </Link>
+
+          <div className="flex items-center gap-3">
+            {prevId && (
+              <button
+                type="button"
+                onClick={goToPrev}
+                disabled={isAnimating}
+                className="inline-flex items-center gap-1 px-3 py-1.5 text-sm text-text-sub hover:text-text-main bg-card border border-border-soft rounded-full transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                aria-label="上一篇"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="m15 18-6-6 6-6" />
+                </svg>
+                上一篇
+              </button>
+            )}
+            {nextId && (
+              <button
+                type="button"
+                onClick={goToNext}
+                disabled={isAnimating}
+                className="inline-flex items-center gap-1 px-3 py-1.5 text-sm text-text-sub hover:text-text-main bg-card border border-border-soft rounded-full transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                aria-label="下一篇"
+              >
+                下一篇
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="m9 18 6-6-6-6" />
+                </svg>
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `npx jest src/components/__tests__/PageFlipWrapper.test.tsx`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/PageFlipWrapper.tsx src/components/__tests__/PageFlipWrapper.test.tsx
+git commit -m "feat(PageFlipWrapper): 3D 翻书动画 + 手势检测 + 导航"
+```
+
+---
+
+## Task 4: 整合 diary/[id]/page.tsx
+
+**Files:**
+- Modify: `src/app/diary/[id]/page.tsx`
+
+### Step 1: 修改 page.tsx
+
+将 `src/app/diary/[id]/page.tsx` 替换为：
+
+```tsx
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { getDiaryById, getDiaryNeighbors, getDiaryList } from '@/lib/actions';
+import { PageFlipWrapper } from '@/components/PageFlipWrapper';
+import { DiaryDetail } from '@/components/DiaryDetail';
+
+interface DiaryDetailPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: DiaryDetailPageProps): Promise<Metadata> {
+  const { id } = await params;
+  const entry = await getDiaryById(id);
+  return {
+    title: entry?.title || '日记详情',
+  };
+}
+
+export default async function DiaryDetailPage({
+  params,
+}: DiaryDetailPageProps) {
+  const { id } = await params;
+  const [entry, { prev, next }, allEntries] = await Promise.all([
+    getDiaryById(id),
+    getDiaryNeighbors(id),
+    getDiaryList(),
+  ]);
+
+  if (!entry) {
+    notFound();
+  }
+
+  const entryNumber = allEntries.length - allEntries.findIndex((e) => e.id === id);
+
+  return (
+    <PageFlipWrapper prevId={prev} nextId={next} currentId={id}>
+      <DiaryDetail entry={entry} entryNumber={entryNumber} />
+    </PageFlipWrapper>
+  );
+}
+```
+
+- [ ] **Step 2: 运行构建确认无错误**
+
+Run: `pnpm build`
+Expected: Build 成功，无 TypeScript 错误
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/diary/[id]/page.tsx
+git commit -m "feat(diary/[id]): 整合翻书动画、篇数序号、邻居导航"
+```
+
+---
+
+## Task 5: 全量验证
+
+- [ ] **Step 1: 运行全部测试**
+
+Run: `npx jest`
+Expected: 所有测试通过（包括新增和已有测试）
+
+- [ ] **Step 2: 运行 ESLint**
+
+Run: `pnpm lint`
+Expected: 无错误，无警告
+
+- [ ] **Step 3: 运行构建**
+
+Run: `pnpm build`
+Expected: Build 成功
+
+- [ ] **Step 4: Commit（如 lint 或测试有修改）**
+
+```bash
+git add -A
+git commit -m "fix: lint and test fixes" || echo "No changes to commit"
+```
+
+---
+
+## Self-Review Checklist
+
+### Spec Coverage
+
+| Spec 要求 | 对应 Task |
+|-----------|-----------|
+| 篇数序号展示 | Task 1 |
+| 上一篇/下一篇导航按钮 | Task 2, Task 3 |
+| Framer Motion 翻书动画 | Task 3 |
+| 左右滑动手势 | Task 3 |
+| 时间线按钮 | Task 2, Task 3 |
+| 返回封面按钮 | Task 3 |
+| 第一篇/最后一篇边界隐藏 | Task 2, Task 3 |
+| prefers-reduced-motion | Task 3 |
+| 动画期间禁用交互 | Task 3 |
+| 日记卡片大圆角 + 奶油色边框 | Task 3 (bg-card rounded-2xl) |
+| 图片自适应 + 圆角 | Task 1 (已有) |
+
+### Placeholder Scan
+
+- [x] 无 "TBD", "TODO", "implement later"
+- [x] 无 "Add appropriate error handling" 等模糊描述
+- [x] 每个测试都包含具体断言
+- [x] 每个代码步骤都包含完整代码块
+
+### Type Consistency
+
+- [x] `getDiaryNeighbors` 返回 `{ prev, next }`（与 actions.ts 一致）
+- [x] `DiaryDetailProps.entryNumber` 为 `number`（非 string）
+- [x] `PageFlipWrapper` 接收 `currentId: string` 作为 AnimatePresence key

--- a/docs/superpowers/specs/2026-05-04-diary-page-flip-design.md
+++ b/docs/superpowers/specs/2026-05-04-diary-page-flip-design.md
@@ -1,0 +1,220 @@
+# Issue #8：单篇日记页 + 翻书动画 — 设计文档
+
+## 1. 目标
+
+实现单篇日记阅读页的核心体验：支持上一篇/下一篇导航，带有整页 3D 翻书动画效果，支持左右滑动手势切换。
+
+## 2. 范围
+
+### 包含
+- 单篇日记完整内容展示（心情标签、篇数序号、标题、正文、外链图片）
+- 上一篇/下一篇导航按钮
+- Framer Motion 3D 翻书动画（rotateY + perspective）
+- 左右滑动手势切换
+- 底部：时间线按钮 + 上一篇/下一篇按钮
+- 顶部：返回封面按钮 + 日期
+
+### 不包含
+- 编辑功能（Issue #9）
+- 删除功能（Issue #9）
+- 评论/点赞
+
+## 3. 组件架构
+
+```
+src/app/diary/[id]/page.tsx          # Server Component（数据获取）
+src/components/PageFlipWrapper.tsx    # Client Component（翻书动画 + 手势）
+src/components/DiaryNavigation.tsx    # 底部导航按钮
+src/components/DiaryDetail.tsx        # 现有组件复用（日记内容展示）
+```
+
+### 3.1 page.tsx（Server Component）
+
+- 调用 `getDiaryById(id)` 获取当前日记
+- 调用 `getDiaryNeighbors(id)` 获取上一篇/下一篇 ID
+- 将数据传给 `PageFlipWrapper`
+- 保留现有 `generateMetadata` 生成页面标题
+
+### 3.2 PageFlipWrapper（Client Component）
+
+状态：
+- `direction: 'left' | 'right' | null` — 翻页方向
+- `isAnimating: boolean` — 动画锁
+
+职责：
+- 3D 透视容器（`perspective: 1200px`）
+- `AnimatePresence mode="wait"` 管理 enter/exit 动画
+- 触摸事件监听（原生 Touch API）
+- 动画完成后 `router.push` 到新 URL
+
+### 3.3 DiaryNavigation
+
+- 接收 `prevId`、`nextId`
+- 边界时隐藏对应按钮
+- 点击时触发父组件的翻页函数
+- 时间线按钮始终显示，跳转 `/diary`
+
+## 4. 数据流
+
+```
+page.tsx (Server)
+  ├─ entry = getDiaryById(id)
+  ├─ { prevId, nextId } = getDiaryNeighbors(id)
+  └─ 渲染 <PageFlipWrapper entry={entry} prevId={prevId} nextId={nextId} />
+
+PageFlipWrapper (Client)
+  ├─ 初始化 direction = null, isAnimating = false
+  ├─ 用户点击/手势触发翻页：
+  │   1. 设置 direction（'left' 或 'right'）
+  │   2. isAnimating = true
+  │   3. AnimatePresence exit 动画（当前页 rotateY 翻走）
+  │   4. onAnimationComplete → router.push(`/diary/${targetId}`)
+  └─ 新 page.tsx 渲染，新 entry 从相反方向翻入
+```
+
+## 5. 翻书动画实现
+
+### 5.1 3D 容器
+
+```tsx
+<div
+  style={{
+    perspective: '1200px',
+    transformStyle: 'preserve-3d',
+  }}
+>
+  <AnimatePresence mode="wait" initial={false}>
+    <motion.div
+      key={entry.id}
+      custom={direction}
+      variants={pageVariants}
+      initial="enter"
+      animate="center"
+      exit="exit"
+      transition={{ duration: 0.4, ease: 'easeInOut' }}
+      onAnimationComplete={() => setIsAnimating(false)}
+      style={{
+        transformStyle: 'preserve-3d',
+        backfaceVisibility: 'hidden',
+      }}
+    >
+      {/* 整页内容 */}
+    </motion.div>
+  </AnimatePresence>
+</div>
+```
+
+### 5.2 动画 Variants
+
+| 方向 | enter | exit |
+|------|-------|------|
+| 下一篇（向右翻） | `rotateY: 90`, `x: '50%'` | `rotateY: -90`, `x: '-50%'` |
+| 上一篇（向左翻） | `rotateY: -90`, `x: '-50%'` | `rotateY: 90`, `x: '50%'` |
+| center | `rotateY: 0`, `x: 0`, `opacity: 1` | — |
+
+所有状态的 `opacity` 在 enter 时为 0，center 时为 1，exit 时为 0。
+
+## 6. 手势检测
+
+使用原生 Touch 事件（不引入额外库）：
+
+```typescript
+const touchStartX = useRef<number | null>(null);
+
+const onTouchStart = (e: TouchEvent) => {
+  if (isAnimating) return;
+  touchStartX.current = e.touches[0].clientX;
+};
+
+const onTouchEnd = (e: TouchEvent) => {
+  if (isAnimating || touchStartX.current === null) return;
+  const diff = e.changedTouches[0].clientX - touchStartX.current;
+  if (diff > 80 && prevId) goToPrev();
+  if (diff < -80 && nextId) goToNext();
+  touchStartX.current = null;
+};
+```
+
+阈值：80px。
+
+## 7. 边界情况处理
+
+| 场景 | 处理 |
+|------|------|
+| 第一篇日记 | 隐藏"上一篇"按钮，右滑无效 |
+| 最后一篇日记 | 隐藏"下一篇"按钮，左滑无效 |
+| 只有一篇日记 | 两个导航按钮都隐藏，手势无效 |
+| 快速连续翻页 | `isAnimating` 锁阻止新翻页请求 |
+| `prefers-reduced-motion` | 检测后跳过动画，直接 `router.push` |
+| 图片加载失败 | 显示占位区域（奶油色背景 + 提示文字） |
+| 手势与图片横向滚动冲突 | 图片区域手势不触发翻页 |
+
+## 8. UI 布局
+
+### 8.1 整页结构（从上到下）
+
+```
+┌─────────────────────────────────┐
+│ ← 返回封面    日期    → 下一篇   │  ← 顶部导航
+├─────────────────────────────────┤
+│                                 │
+│    ┌─────────────────────┐      │
+│    │ 心情标签    第 N 篇  │      │
+│    │                     │      │
+│    │       标题           │      │
+│    │                     │      │
+│    │    正文内容...       │      │  ← 日记卡片（大圆角 16px）
+│    │                     │      │
+│    │    [图片]            │      │
+│    └─────────────────────┘      │
+│                                 │
+├─────────────────────────────────┤
+│ 时间线          上一篇  下一篇   │  ← 底部导航
+└─────────────────────────────────┘
+```
+
+### 8.2 样式规范
+
+- 卡片：`bg-card rounded-2xl p-4 shadow-sm`
+- 图片：`rounded-xl w-full object-cover`
+- 心情标签：使用设计文档中的心情色（开心 `#B8DDA8`、想念 `#AFC9F7` 等）
+- 导航按钮：pill 形状，`rounded-full`，hover 轻微上浮
+
+## 9. 技术依赖
+
+- **framer-motion**：已安装，用于翻书动画
+- **next/navigation**：`useRouter`，用于路由导航
+- **原生 Touch API**：手势检测，无额外依赖
+
+## 10. 与现有代码的集成
+
+### 10.1 复用组件
+
+- `DiaryDetail.tsx`：已有日记内容展示，直接复用
+- `BackButton.tsx`：已有返回按钮组件
+
+### 10.2 Server Actions
+
+需要 `getDiaryNeighbors(id)`：
+
+```typescript
+async function getDiaryNeighbors(id: string): Promise<{
+  prevId: string | null;
+  nextId: string | null;
+}> {
+  // 按 date 排序，找到当前日记的前一篇和后一篇
+}
+```
+
+## 11. 验收标准
+
+- [ ] 正确展示单篇日记完整内容
+- [ ] 显示篇数序号
+- [ ] 上一篇/下一篇按钮导航正确
+- [ ] 第一篇/最后一篇边界按钮隐藏正确
+- [ ] 左右滑动手势切换正常
+- [ ] 翻书动画流畅（400ms，3D rotateY）
+- [ ] 动画期间禁用交互
+- [ ] 支持 `prefers-reduced-motion`
+- [ ] 点击"时间线"跳转到 `/diary`
+- [ ] 图片加载失败有占位处理

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,46 @@
+import { PrismaClient } from '@prisma/client';
+import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3';
+
+const url = process.env.DATABASE_URL ?? 'file:./prisma/dev.db';
+const adapter = new PrismaBetterSqlite3({ url });
+const prisma = new PrismaClient({ adapter });
+
+async function main() {
+  await prisma.diaryEntry.deleteMany();
+
+  const entries = await Promise.all([
+    prisma.diaryEntry.create({
+      data: {
+        date: new Date('2025-01-10'),
+        title: '第一次见面',
+        content: '今天我们在咖啡馆第一次见面，心跳得好快...',
+        mood: 'sweet',
+      },
+    }),
+    prisma.diaryEntry.create({
+      data: {
+        date: new Date('2025-01-15'),
+        title: '一起看电影',
+        content: '看了一部浪漫的爱情电影，牵了手。',
+        mood: 'happy',
+      },
+    }),
+    prisma.diaryEntry.create({
+      data: {
+        date: new Date('2025-01-20'),
+        title: '今天有点想你了',
+        content: '分开的第二天，已经开始想念了。',
+        mood: 'miss',
+      },
+    }),
+  ]);
+
+  console.log(
+    'Created entries:',
+    entries.map((e) => ({ id: e.id, title: e.title })),
+  );
+}
+
+main()
+  .catch(console.error)
+  .finally(() => prisma.$disconnect());

--- a/src/app/diary/[id]/page.tsx
+++ b/src/app/diary/[id]/page.tsx
@@ -1,87 +1,36 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
 import { notFound } from 'next/navigation';
-import { getDiaryById } from '@/lib/actions';
+import { getDiaryById, getDiaryNeighbors, getDiaryList } from '@/lib/actions';
+import { PageFlipWrapper } from '@/components/PageFlipWrapper';
 import { DiaryDetail } from '@/components/DiaryDetail';
 
 interface DiaryDetailPageProps {
   params: Promise<{ id: string }>;
 }
 
-export async function generateMetadata({
-  params,
-}: DiaryDetailPageProps): Promise<Metadata> {
+export async function generateMetadata({ params }: DiaryDetailPageProps): Promise<Metadata> {
   const { id } = await params;
   const entry = await getDiaryById(id);
-  return {
-    title: entry?.title || '日记详情',
-  };
+  return { title: entry?.title || '日记详情' };
 }
 
-export default async function DiaryDetailPage({
-  params,
-}: DiaryDetailPageProps) {
+export default async function DiaryDetailPage({ params }: DiaryDetailPageProps) {
   const { id } = await params;
-  const entry = await getDiaryById(id);
+  const [entry, { prev, next }, allEntries] = await Promise.all([
+    getDiaryById(id),
+    getDiaryNeighbors(id),
+    getDiaryList(),
+  ]);
 
   if (!entry) {
     notFound();
   }
 
+  const entryNumber = allEntries.length - allEntries.findIndex((e) => e.id === id);
+
   return (
-    <main className="min-h-screen bg-cream">
-      <div className="max-w-[480px] mx-auto px-4 py-6">
-        <div className="flex items-center gap-4 mb-6">
-          <Link
-            href="/diary/new"
-            className="text-text-sub hover:text-text-main transition-colors"
-            aria-label="返回"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="20"
-              height="20"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="m15 18-6-6 6-6" />
-            </svg>
-          </Link>
-          <h1 className="text-lg font-bold text-text-main">日记详情</h1>
-        </div>
-        <div className="bg-card rounded-2xl p-4 shadow-sm">
-          <DiaryDetail entry={entry} />
-        </div>
-        <div className="mt-6 flex justify-center">
-          <Link
-            href="/diary"
-            className="inline-flex items-center gap-2 text-sm text-text-sub hover:text-text-main transition-colors"
-            aria-label="返回时间线"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <line x1="21" y1="10" x2="3" y2="10" />
-              <line x1="21" y1="6" x2="3" y2="6" />
-              <line x1="21" y1="14" x2="3" y2="14" />
-              <line x1="21" y1="18" x2="3" y2="18" />
-            </svg>
-            时间线
-          </Link>
-        </div>
-      </div>
-    </main>
+    <PageFlipWrapper prevId={prev} nextId={next} currentId={id}>
+      <DiaryDetail entry={entry} entryNumber={entryNumber} />
+    </PageFlipWrapper>
   );
 }

--- a/src/components/DiaryDetail.tsx
+++ b/src/components/DiaryDetail.tsx
@@ -4,6 +4,7 @@ import type { DiaryEntry, DiaryImage } from '@prisma/client';
 
 interface DiaryDetailProps {
   entry: DiaryEntry & { images: DiaryImage[] };
+  entryNumber?: number;
 }
 
 const moodMap: Record<string, { label: string; color: string }> = {
@@ -14,7 +15,7 @@ const moodMap: Record<string, { label: string; color: string }> = {
   sad: { label: '小难过', color: '#E8C4A0' },
 };
 
-export function DiaryDetail({ entry }: DiaryDetailProps) {
+export function DiaryDetail({ entry, entryNumber }: DiaryDetailProps) {
   const displayTitle =
     entry.title || `${dayjs(entry.date).format('YYYY年M月D日')} 的心情`;
   const mood = moodMap[entry.mood] || moodMap.sweet;
@@ -23,18 +24,23 @@ export function DiaryDetail({ entry }: DiaryDetailProps) {
     <article className="space-y-4">
       <h1 className="text-xl font-bold text-text-main">{displayTitle}</h1>
 
-      <div className="flex items-center gap-2 text-sm text-text-sub">
-        <span>{dayjs(entry.date).format('YYYY年M月D日')}</span>
-        <span
-          className="flex items-center gap-1 px-2 py-0.5 rounded-full"
-          style={{ backgroundColor: mood.color + '33' }}
-        >
+      <div className="flex items-center justify-between text-sm text-text-sub">
+        <div className="flex items-center gap-2">
+          <span>{dayjs(entry.date).format('YYYY年M月D日')}</span>
           <span
-            className="w-2 h-2 rounded-full"
-            style={{ backgroundColor: mood.color }}
-          />
-          {mood.label}
-        </span>
+            className="flex items-center gap-1 px-2 py-0.5 rounded-full"
+            style={{ backgroundColor: mood.color + '33' }}
+          >
+            <span
+              className="w-2 h-2 rounded-full"
+              style={{ backgroundColor: mood.color }}
+            />
+            {mood.label}
+          </span>
+        </div>
+        {entryNumber != null && (
+          <span>第 {entryNumber} 篇</span>
+        )}
       </div>
 
       <p className="text-base text-text-main whitespace-pre-wrap leading-relaxed">

--- a/src/components/DiaryNavigation.tsx
+++ b/src/components/DiaryNavigation.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import Link from 'next/link';
+
+export interface DiaryNavigationProps {
+  prevId: string | null;
+  nextId: string | null;
+  onPrev: () => void;
+  onNext: () => void;
+}
+
+export function DiaryNavigation({ prevId, nextId, onPrev, onNext }: DiaryNavigationProps) {
+  const showNav = prevId !== null || nextId !== null;
+
+  return (
+    <div className="flex items-center justify-between">
+      <Link
+        href="/diary"
+        className="inline-flex items-center gap-1.5 text-sm text-text-sub hover:text-text-main transition-colors"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <line x1="21" y1="10" x2="3" y2="10" />
+          <line x1="21" y1="6" x2="3" y2="6" />
+          <line x1="21" y1="14" x2="3" y2="14" />
+          <line x1="21" y1="18" x2="3" y2="18" />
+        </svg>
+        时间线
+      </Link>
+
+      {showNav && (
+        <div className="flex gap-3">
+          {prevId !== null && (
+            <button
+              type="button"
+              onClick={onPrev}
+              className="inline-flex items-center gap-1 px-3 py-1.5 text-sm text-text-sub hover:text-text-main bg-card border border-border-soft rounded-full transition-colors"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="m15 18-6-6 6-6" />
+              </svg>
+              上一篇
+            </button>
+          )}
+          {nextId !== null && (
+            <button
+              type="button"
+              onClick={onNext}
+              className="inline-flex items-center gap-1 px-3 py-1.5 text-sm text-text-sub hover:text-text-main bg-card border border-border-soft rounded-full transition-colors"
+            >
+              下一篇
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="m9 18 6-6-6-6" />
+              </svg>
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/PageFlipWrapper.tsx
+++ b/src/components/PageFlipWrapper.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useLayoutEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { motion, AnimatePresence } from 'framer-motion';
@@ -41,43 +41,50 @@ export function PageFlipWrapper({
 }: PageFlipWrapperProps) {
   const router = useRouter();
   const [isExiting, setIsExiting] = useState(false);
-  const [direction, setDirection] = useState<Direction | null>(() => {
-    if (typeof window !== 'undefined') {
-      const saved = sessionStorage.getItem('pageFlipDirection');
-      if (saved) {
-        sessionStorage.removeItem('pageFlipDirection');
-        return saved as Direction;
-      }
-    }
-    return null;
-  });
+  const [direction, setDirection] = useState<Direction | null>(null);
+  const directionRef = useRef<Direction | null>(null);
   const touchStartX = useRef<number | null>(null);
+
+  useLayoutEffect(() => {
+    const saved = sessionStorage.getItem('pageFlipDirection');
+    if (saved) {
+      sessionStorage.removeItem('pageFlipDirection');
+      const dir = saved as Direction;
+      directionRef.current = dir;
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setDirection(dir);
+    }
+  }, []);
 
   const prefersReducedMotion =
     typeof window !== 'undefined' &&
     window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
   const handleExitComplete = useCallback(() => {
-    if (!direction) return;
-    const targetId = direction === 'right' ? nextId : prevId;
+    const dir = directionRef.current;
+    if (!dir) return;
+    const targetId = dir === 'right' ? nextId : prevId;
     if (targetId) {
       if (prefersReducedMotion) {
         router.push(`/diary/${targetId}`);
       } else {
-        sessionStorage.setItem('pageFlipDirection', direction);
+        sessionStorage.setItem('pageFlipDirection', dir);
         router.push(`/diary/${targetId}`);
       }
     }
-  }, [direction, prevId, nextId, router, prefersReducedMotion]);
+    directionRef.current = null;
+  }, [prevId, nextId, router, prefersReducedMotion]);
 
   const goToPrev = useCallback(() => {
     if (isExiting || prevId === null) return;
+    directionRef.current = 'left';
     setDirection('left');
     setIsExiting(true);
   }, [isExiting, prevId]);
 
   const goToNext = useCallback(() => {
     if (isExiting || nextId === null) return;
+    directionRef.current = 'right';
     setDirection('right');
     setIsExiting(true);
   }, [isExiting, nextId]);

--- a/src/components/PageFlipWrapper.tsx
+++ b/src/components/PageFlipWrapper.tsx
@@ -40,55 +40,59 @@ export function PageFlipWrapper({
   currentId,
 }: PageFlipWrapperProps) {
   const router = useRouter();
-  const [direction, setDirection] = useState<Direction | null>(null);
-  const [isAnimating, setIsAnimating] = useState(false);
+  const [isExiting, setIsExiting] = useState(false);
+  const [direction, setDirection] = useState<Direction | null>(() => {
+    if (typeof window !== 'undefined') {
+      const saved = sessionStorage.getItem('pageFlipDirection');
+      if (saved) {
+        sessionStorage.removeItem('pageFlipDirection');
+        return saved as Direction;
+      }
+    }
+    return null;
+  });
   const touchStartX = useRef<number | null>(null);
 
   const prefersReducedMotion =
     typeof window !== 'undefined' &&
     window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-  const navigateTo = useCallback(
-    (targetId: string, dir: Direction) => {
+  const handleExitComplete = useCallback(() => {
+    if (!direction) return;
+    const targetId = direction === 'right' ? nextId : prevId;
+    if (targetId) {
       if (prefersReducedMotion) {
         router.push(`/diary/${targetId}`);
-        return;
+      } else {
+        sessionStorage.setItem('pageFlipDirection', direction);
+        router.push(`/diary/${targetId}`);
       }
-      setDirection(dir);
-      setIsAnimating(true);
-    },
-    [prefersReducedMotion, router]
-  );
+    }
+  }, [direction, prevId, nextId, router, prefersReducedMotion]);
 
   const goToPrev = useCallback(() => {
-    if (isAnimating || prevId === null) return;
-    navigateTo(prevId, 'left');
-  }, [isAnimating, prevId, navigateTo]);
+    if (isExiting || prevId === null) return;
+    setDirection('left');
+    setIsExiting(true);
+  }, [isExiting, prevId]);
 
   const goToNext = useCallback(() => {
-    if (isAnimating || nextId === null) return;
-    navigateTo(nextId, 'right');
-  }, [isAnimating, nextId, navigateTo]);
-
-  const handleAnimationComplete = useCallback(() => {
-    if (direction === 'left' && prevId !== null) {
-      router.push(`/diary/${prevId}`);
-    } else if (direction === 'right' && nextId !== null) {
-      router.push(`/diary/${nextId}`);
-    }
-  }, [direction, prevId, nextId, router]);
+    if (isExiting || nextId === null) return;
+    setDirection('right');
+    setIsExiting(true);
+  }, [isExiting, nextId]);
 
   const handleTouchStart = useCallback(
     (e: React.TouchEvent) => {
-      if (isAnimating) return;
+      if (isExiting) return;
       touchStartX.current = e.touches[0].clientX;
     },
-    [isAnimating]
+    [isExiting]
   );
 
   const handleTouchEnd = useCallback(
     (e: React.TouchEvent) => {
-      if (isAnimating || touchStartX.current === null) return;
+      if (isExiting || touchStartX.current === null) return;
       const diff = e.changedTouches[0].clientX - touchStartX.current;
       if (diff > 80) {
         goToPrev();
@@ -97,7 +101,7 @@ export function PageFlipWrapper({
       }
       touchStartX.current = null;
     },
-    [isAnimating, goToPrev, goToNext]
+    [isExiting, goToPrev, goToNext]
   );
 
   return (
@@ -134,7 +138,7 @@ export function PageFlipWrapper({
               <button
                 type="button"
                 aria-label="上一篇"
-                disabled={isAnimating}
+                disabled={isExiting}
                 onClick={goToPrev}
                 className="text-text-sub hover:text-text-main transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
@@ -157,7 +161,7 @@ export function PageFlipWrapper({
               <button
                 type="button"
                 aria-label="下一篇"
-                disabled={isAnimating}
+                disabled={isExiting}
                 onClick={goToNext}
                 className="text-text-sub hover:text-text-main transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
@@ -184,25 +188,26 @@ export function PageFlipWrapper({
           className="mb-6"
           style={{ perspective: '1200px', transformStyle: 'preserve-3d' }}
         >
-          <AnimatePresence mode="wait" initial={false}>
-            <motion.div
-              key={currentId}
-              custom={direction}
-              variants={variants}
-              initial="enter"
-              animate="center"
-              exit="exit"
-              transition={{ duration: 0.4, ease: 'easeInOut' }}
-              onAnimationComplete={handleAnimationComplete}
-              style={{
-                transformStyle: 'preserve-3d',
-                backfaceVisibility: 'hidden',
-              }}
-            >
-              <div className="bg-card rounded-2xl p-4 shadow-sm">
-                {children}
-              </div>
-            </motion.div>
+          <AnimatePresence mode="wait" onExitComplete={handleExitComplete}>
+            {!isExiting && (
+              <motion.div
+                key={currentId}
+                custom={direction}
+                variants={variants}
+                initial={direction ? 'enter' : false}
+                animate="center"
+                exit="exit"
+                transition={{ duration: 0.4, ease: 'easeInOut' }}
+                style={{
+                  transformStyle: 'preserve-3d',
+                  backfaceVisibility: 'hidden',
+                }}
+              >
+                <div className="bg-card rounded-2xl p-4 shadow-sm">
+                  {children}
+                </div>
+              </motion.div>
+            )}
           </AnimatePresence>
         </div>
 

--- a/src/components/PageFlipWrapper.tsx
+++ b/src/components/PageFlipWrapper.tsx
@@ -1,0 +1,219 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { motion, AnimatePresence } from 'framer-motion';
+import { DiaryNavigation } from './DiaryNavigation';
+
+type Direction = 'left' | 'right';
+
+interface PageFlipWrapperProps {
+  children: React.ReactNode;
+  prevId: string | null;
+  nextId: string | null;
+  currentId: string;
+}
+
+const variants = {
+  enter: (dir: Direction | null) => ({
+    rotateY: dir === 'right' ? 90 : -90,
+    opacity: 0,
+    x: dir === 'right' ? '50%' : '-50%',
+  }),
+  center: {
+    rotateY: 0,
+    opacity: 1,
+    x: 0,
+  },
+  exit: (dir: Direction | null) => ({
+    rotateY: dir === 'right' ? -90 : 90,
+    opacity: 0,
+    x: dir === 'right' ? '-50%' : '50%',
+  }),
+};
+
+export function PageFlipWrapper({
+  children,
+  prevId,
+  nextId,
+  currentId,
+}: PageFlipWrapperProps) {
+  const router = useRouter();
+  const [direction, setDirection] = useState<Direction | null>(null);
+  const [isAnimating, setIsAnimating] = useState(false);
+  const touchStartX = useRef<number | null>(null);
+
+  const prefersReducedMotion =
+    typeof window !== 'undefined' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  const navigateTo = useCallback(
+    (targetId: string, dir: Direction) => {
+      if (prefersReducedMotion) {
+        router.push(`/diary/${targetId}`);
+        return;
+      }
+      setDirection(dir);
+      setIsAnimating(true);
+    },
+    [prefersReducedMotion, router]
+  );
+
+  const goToPrev = useCallback(() => {
+    if (isAnimating || prevId === null) return;
+    navigateTo(prevId, 'left');
+  }, [isAnimating, prevId, navigateTo]);
+
+  const goToNext = useCallback(() => {
+    if (isAnimating || nextId === null) return;
+    navigateTo(nextId, 'right');
+  }, [isAnimating, nextId, navigateTo]);
+
+  const handleAnimationComplete = useCallback(() => {
+    if (direction === 'left' && prevId !== null) {
+      router.push(`/diary/${prevId}`);
+    } else if (direction === 'right' && nextId !== null) {
+      router.push(`/diary/${nextId}`);
+    }
+  }, [direction, prevId, nextId, router]);
+
+  const handleTouchStart = useCallback(
+    (e: React.TouchEvent) => {
+      if (isAnimating) return;
+      touchStartX.current = e.touches[0].clientX;
+    },
+    [isAnimating]
+  );
+
+  const handleTouchEnd = useCallback(
+    (e: React.TouchEvent) => {
+      if (isAnimating || touchStartX.current === null) return;
+      const diff = e.changedTouches[0].clientX - touchStartX.current;
+      if (diff > 80) {
+        goToPrev();
+      } else if (diff < -80) {
+        goToNext();
+      }
+      touchStartX.current = null;
+    },
+    [isAnimating, goToPrev, goToNext]
+  );
+
+  return (
+    <div
+      className="min-h-screen bg-cream"
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+    >
+      <div className="max-w-[480px] mx-auto px-4 py-6">
+        {/* 顶部导航 */}
+        <div className="flex items-center justify-between mb-6">
+          <Link
+            href="/"
+            className="inline-flex items-center gap-1 text-sm text-text-sub hover:text-text-main transition-colors"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="m15 18-6-6 6-6" />
+            </svg>
+            封面
+          </Link>
+
+          <div className="flex gap-2">
+            {prevId !== null && (
+              <button
+                type="button"
+                aria-label="上一篇"
+                disabled={isAnimating}
+                onClick={goToPrev}
+                className="text-text-sub hover:text-text-main transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="m15 18-6-6 6-6" />
+                </svg>
+              </button>
+            )}
+            {nextId !== null && (
+              <button
+                type="button"
+                aria-label="下一篇"
+                disabled={isAnimating}
+                onClick={goToNext}
+                className="text-text-sub hover:text-text-main transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="m9 18 6-6-6-6" />
+                </svg>
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* 3D 翻书容器 */}
+        <div
+          className="mb-6"
+          style={{ perspective: '1200px', transformStyle: 'preserve-3d' }}
+        >
+          <AnimatePresence mode="wait" initial={false}>
+            <motion.div
+              key={currentId}
+              custom={direction}
+              variants={variants}
+              initial="enter"
+              animate="center"
+              exit="exit"
+              transition={{ duration: 0.4, ease: 'easeInOut' }}
+              onAnimationComplete={handleAnimationComplete}
+              style={{
+                transformStyle: 'preserve-3d',
+                backfaceVisibility: 'hidden',
+              }}
+            >
+              <div className="bg-card rounded-2xl p-4 shadow-sm">
+                {children}
+              </div>
+            </motion.div>
+          </AnimatePresence>
+        </div>
+
+        {/* 底部导航 */}
+        <DiaryNavigation
+          prevId={prevId}
+          nextId={nextId}
+          onPrev={goToPrev}
+          onNext={goToNext}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/__tests__/DiaryDetail.test.tsx
+++ b/src/components/__tests__/DiaryDetail.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import type { DiaryEntry, DiaryImage } from '@prisma/client';
+import { DiaryDetail } from '../DiaryDetail';
+
+type Entry = DiaryEntry & { images: DiaryImage[] };
+
+function makeEntry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    id: overrides.id ?? 'id1',
+    date: overrides.date ?? new Date('2025-01-15'),
+    title: overrides.title === undefined ? 'Test Title' : overrides.title,
+    content: overrides.content ?? 'content',
+    mood: overrides.mood ?? 'sweet',
+    weather: overrides.weather ?? null,
+    createdAt: overrides.createdAt ?? new Date(),
+    updatedAt: overrides.updatedAt ?? new Date(),
+    images: overrides.images ?? [],
+  } as Entry;
+}
+
+describe('DiaryDetail', () => {
+  it('传入 entryNumber={12} 时显示"第 12 篇"', () => {
+    render(<DiaryDetail entry={makeEntry()} entryNumber={12} />);
+    expect(screen.getByText('第 12 篇')).toBeInTheDocument();
+  });
+
+  it('不传 entryNumber 时不显示篇数', () => {
+    render(<DiaryDetail entry={makeEntry()} />);
+    expect(screen.queryByText(/第 \d+ 篇/)).not.toBeInTheDocument();
+  });
+
+  it('标题和内容渲染正常', () => {
+    render(<DiaryDetail entry={makeEntry({ title: 'My Day', content: 'Today was great.' })} />);
+    expect(screen.getByText('My Day')).toBeInTheDocument();
+    expect(screen.getByText('Today was great.')).toBeInTheDocument();
+  });
+
+  it('标题为 null 时显示默认标题', () => {
+    render(<DiaryDetail entry={makeEntry({ title: null })} />);
+    expect(screen.getByText('2025年1月15日 的心情')).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/DiaryNavigation.test.tsx
+++ b/src/components/__tests__/DiaryNavigation.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DiaryNavigation } from '../DiaryNavigation';
+
+describe('DiaryNavigation', () => {
+  const mockOnPrev = jest.fn();
+  const mockOnNext = jest.fn();
+
+  beforeEach(() => {
+    mockOnPrev.mockClear();
+    mockOnNext.mockClear();
+  });
+
+  it('两个邻居都存在时，显示所有按钮（时间线、上一篇、下一篇）', () => {
+    render(
+      <DiaryNavigation
+        prevId="prev-1"
+        nextId="next-1"
+        onPrev={mockOnPrev}
+        onNext={mockOnNext}
+      />
+    );
+
+    expect(screen.getByText('时间线')).toBeInTheDocument();
+    expect(screen.getByText('上一篇')).toBeInTheDocument();
+    expect(screen.getByText('下一篇')).toBeInTheDocument();
+  });
+
+  it('prevId 为 null 时隐藏上一篇按钮', () => {
+    render(
+      <DiaryNavigation
+        prevId={null}
+        nextId="next-1"
+        onPrev={mockOnPrev}
+        onNext={mockOnNext}
+      />
+    );
+
+    expect(screen.queryByText('上一篇')).not.toBeInTheDocument();
+    expect(screen.getByText('下一篇')).toBeInTheDocument();
+    expect(screen.getByText('时间线')).toBeInTheDocument();
+  });
+
+  it('nextId 为 null 时隐藏下一篇按钮', () => {
+    render(
+      <DiaryNavigation
+        prevId="prev-1"
+        nextId={null}
+        onPrev={mockOnPrev}
+        onNext={mockOnNext}
+      />
+    );
+
+    expect(screen.getByText('上一篇')).toBeInTheDocument();
+    expect(screen.queryByText('下一篇')).not.toBeInTheDocument();
+    expect(screen.getByText('时间线')).toBeInTheDocument();
+  });
+
+  it('两个都为 null 时隐藏两个导航按钮', () => {
+    render(
+      <DiaryNavigation
+        prevId={null}
+        nextId={null}
+        onPrev={mockOnPrev}
+        onNext={mockOnNext}
+      />
+    );
+
+    expect(screen.queryByText('上一篇')).not.toBeInTheDocument();
+    expect(screen.queryByText('下一篇')).not.toBeInTheDocument();
+    expect(screen.getByText('时间线')).toBeInTheDocument();
+  });
+
+  it('点击上一篇调用 onPrev', () => {
+    render(
+      <DiaryNavigation
+        prevId="prev-1"
+        nextId="next-1"
+        onPrev={mockOnPrev}
+        onNext={mockOnNext}
+      />
+    );
+
+    fireEvent.click(screen.getByText('上一篇'));
+    expect(mockOnPrev).toHaveBeenCalledTimes(1);
+    expect(mockOnNext).not.toHaveBeenCalled();
+  });
+
+  it('点击下一篇调用 onNext', () => {
+    render(
+      <DiaryNavigation
+        prevId="prev-1"
+        nextId="next-1"
+        onPrev={mockOnPrev}
+        onNext={mockOnNext}
+      />
+    );
+
+    fireEvent.click(screen.getByText('下一篇'));
+    expect(mockOnNext).toHaveBeenCalledTimes(1);
+    expect(mockOnPrev).not.toHaveBeenCalled();
+  });
+
+  it('时间线按钮链接到 /diary', () => {
+    render(
+      <DiaryNavigation
+        prevId="prev-1"
+        nextId="next-1"
+        onPrev={mockOnPrev}
+        onNext={mockOnNext}
+      />
+    );
+
+    const timelineLink = screen.getByText('时间线').closest('a');
+    expect(timelineLink).toHaveAttribute('href', '/diary');
+  });
+});

--- a/src/components/__tests__/PageFlipWrapper.test.tsx
+++ b/src/components/__tests__/PageFlipWrapper.test.tsx
@@ -21,20 +21,45 @@ Object.defineProperty(window, 'matchMedia', {
   })),
 });
 
+const mockSessionStorage = (() => {
+  const store: Record<string, string> = {};
+  return {
+    getItem: jest.fn((key: string) => store[key] || null),
+    setItem: jest.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: jest.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: jest.fn(() => {
+      Object.keys(store).forEach((k) => delete store[k]);
+    }),
+  };
+})();
+
+Object.defineProperty(window, 'sessionStorage', {
+  writable: true,
+  value: mockSessionStorage,
+});
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 jest.mock('framer-motion', () => ({
   motion: {
-    div: ({ children, onAnimationComplete, ...props }: any) => {
-      if (onAnimationComplete) onAnimationComplete();
-      return <div {...props}>{children}</div>;
-    },
+    div: ({ children, ...props }: any) => <div {...props}>{children}</div>,
   },
-  AnimatePresence: ({ children }: any) => <>{children}</>,
+  AnimatePresence: ({ children, onExitComplete }: any) => {
+    // 当 children 被移除时（exit），立即触发 onExitComplete 模拟动画完成
+    if (!children && onExitComplete) {
+      onExitComplete();
+    }
+    return <>{children}</>;
+  },
 }));
 
 describe('PageFlipWrapper', () => {
   beforeEach(() => {
     mockPush.mockClear();
+    mockSessionStorage.clear();
   });
 
   it('渲染 children 内容', () => {
@@ -59,6 +84,7 @@ describe('PageFlipWrapper', () => {
     await waitFor(() => {
       expect(mockPush).toHaveBeenCalledWith('/diary/prev1');
     });
+    expect(mockSessionStorage.setItem).toHaveBeenCalledWith('pageFlipDirection', 'left');
   });
 
   it('点击下一篇按钮后调用 router.push', async () => {
@@ -73,6 +99,7 @@ describe('PageFlipWrapper', () => {
     await waitFor(() => {
       expect(mockPush).toHaveBeenCalledWith('/diary/next1');
     });
+    expect(mockSessionStorage.setItem).toHaveBeenCalledWith('pageFlipDirection', 'right');
   });
 
   it('prevId 为 null 时隐藏上一篇按钮', () => {
@@ -106,5 +133,20 @@ describe('PageFlipWrapper', () => {
 
     expect(screen.queryByLabelText('上一篇')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('下一篇')).not.toBeInTheDocument();
+  });
+
+  it('点击按钮后禁用导航按钮（动画锁）', () => {
+    render(
+      <PageFlipWrapper prevId="prev1" nextId="next1" currentId="id1">
+        <div>内容</div>
+      </PageFlipWrapper>
+    );
+
+    const prevBtn = screen.getByLabelText('上一篇');
+    fireEvent.click(prevBtn);
+
+    // 按钮被 disabled
+    expect(prevBtn).toBeDisabled();
+    expect(screen.getByLabelText('下一篇')).toBeDisabled();
   });
 });

--- a/src/components/__tests__/PageFlipWrapper.test.tsx
+++ b/src/components/__tests__/PageFlipWrapper.test.tsx
@@ -21,6 +21,7 @@ Object.defineProperty(window, 'matchMedia', {
   })),
 });
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
 jest.mock('framer-motion', () => ({
   motion: {
     div: ({ children, onAnimationComplete, ...props }: any) => {

--- a/src/components/__tests__/PageFlipWrapper.test.tsx
+++ b/src/components/__tests__/PageFlipWrapper.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { PageFlipWrapper } from '../PageFlipWrapper';
+
+const mockPush = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});
+
+jest.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, onAnimationComplete, ...props }: any) => {
+      if (onAnimationComplete) onAnimationComplete();
+      return <div {...props}>{children}</div>;
+    },
+  },
+  AnimatePresence: ({ children }: any) => <>{children}</>,
+}));
+
+describe('PageFlipWrapper', () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+  });
+
+  it('渲染 children 内容', () => {
+    render(
+      <PageFlipWrapper prevId="prev1" nextId="next1" currentId="id1">
+        <div data-testid="child">日记内容</div>
+      </PageFlipWrapper>
+    );
+
+    expect(screen.getByTestId('child')).toHaveTextContent('日记内容');
+  });
+
+  it('点击上一篇按钮后调用 router.push', async () => {
+    render(
+      <PageFlipWrapper prevId="prev1" nextId="next1" currentId="id1">
+        <div>内容</div>
+      </PageFlipWrapper>
+    );
+
+    fireEvent.click(screen.getByLabelText('上一篇'));
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/diary/prev1');
+    });
+  });
+
+  it('点击下一篇按钮后调用 router.push', async () => {
+    render(
+      <PageFlipWrapper prevId="prev1" nextId="next1" currentId="id1">
+        <div>内容</div>
+      </PageFlipWrapper>
+    );
+
+    fireEvent.click(screen.getByLabelText('下一篇'));
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/diary/next1');
+    });
+  });
+
+  it('prevId 为 null 时隐藏上一篇按钮', () => {
+    render(
+      <PageFlipWrapper prevId={null} nextId="next1" currentId="id1">
+        <div>内容</div>
+      </PageFlipWrapper>
+    );
+
+    expect(screen.queryByLabelText('上一篇')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('下一篇')).toBeInTheDocument();
+  });
+
+  it('nextId 为 null 时隐藏下一篇按钮', () => {
+    render(
+      <PageFlipWrapper prevId="prev1" nextId={null} currentId="id1">
+        <div>内容</div>
+      </PageFlipWrapper>
+    );
+
+    expect(screen.getByLabelText('上一篇')).toBeInTheDocument();
+    expect(screen.queryByLabelText('下一篇')).not.toBeInTheDocument();
+  });
+
+  it('两个都为 null 时隐藏两个按钮', () => {
+    render(
+      <PageFlipWrapper prevId={null} nextId={null} currentId="id1">
+        <div>内容</div>
+      </PageFlipWrapper>
+    );
+
+    expect(screen.queryByLabelText('上一篇')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('下一篇')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #8

## 实现内容

### 页面与组件
- `src/app/diary/[id]/page.tsx` — 单篇日记服务端页面，获取当前日记 + 邻居 ID + 篇数序号
- `src/components/PageFlipWrapper.tsx` — 3D 翻书动画容器，支持按钮点击 + 左右滑动手势
- `src/components/DiaryDetail.tsx` — 日记详情展示（标题、日期、心情、正文、篇数序号）
- `src/components/DiaryNavigation.tsx` — 底部导航（时间线 + 上一篇/下一篇）

### 翻书动画
- Framer Motion `AnimatePresence` + `motion.div` 实现 3D `rotateY` 翻页效果
- 当前页 rotateY 从 0 翻走（±90deg），新页从反方向翻入
- 动画期间通过 `isExiting` 状态锁定交互
- 使用 `sessionStorage` 传递翻页方向，确保进入动画连贯
- 支持 `prefers-reduced-motion`，直接切换无动画

### 手势支持
- 原生 Touch API 检测左右滑动（80px 阈值）
- 与按钮点击不冲突

### 边界处理
- 第一篇隐藏"上一篇"，最后一篇隐藏"下一篇"
- 使用 `directionRef` 避免 `useCallback` 闭包捕获过期状态
- 使用 `useLayoutEffect` 读取 `sessionStorage`，消除 SSR/hydration 不匹配

### 测试验证
- 单元测试：`PageFlipWrapper.test.tsx` 覆盖渲染、按钮点击、边界条件、动画锁
- agent-browser 端到端验证：双向导航无 404、无 hydration 错误
- `pnpm lint` 通过，`pnpm build` 成功

## 提交记录
- `feat(DiaryDetail)`: 添加篇数序号展示
- `feat(DiaryNavigation)`: 添加底部上一篇/下一篇/时间线导航
- `feat(PageFlipWrapper)`: 3D 翻书动画 + 手势检测 + 导航
- `feat(diary/[id])`: 整合翻书动画、篇数序号、邻居导航
- `test`: 禁用 framer-motion mock 中的 any 类型 ESLint 规则
- `fix(PageFlipWrapper)`: 修复翻书动画无法触发的问题
- `fix(PageFlipWrapper)`: 修复 404 导航 + hydration 不匹配