### PR TITLE
feat(memories): 添加回忆照片墙页面

### DIFF
--- a/docs/superpowers/plans/2026-05-07-memories-wall.md
+++ b/docs/superpowers/plans/2026-05-07-memories-wall.md
@@ -1,0 +1,721 @@
+# Issue #12 回忆照片墙 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 实现回忆照片墙页面，瀑布流展示所有日记外链图片，支持入场动画、懒加载、双页面入口。
+
+**Architecture:** Server Component (`page.tsx`) 获取 `DiaryImage` 数据并传递给 Client Component (`MasonryGrid`)。`MasonryGrid` 用 ResizeObserver 响应式计算列数（2/3 列），按索引轮询分配图片到各列形成瀑布流效果。每张图片用 `MemoryCard` 包裹，集成 `StaggerItem` 入场动画和 `loading="lazy"` 懒加载。
+
+**Tech Stack:** Next.js 16 App Router, TypeScript, Tailwind CSS v4, Framer Motion, Jest, @testing-library/react
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/lib/actions.ts` | Modify | 新增 `getAllDiaryImages` Server Action |
+| `src/lib/__tests__/actions.test.ts` | Modify | 追加 `getAllDiaryImages` 测试 |
+| `src/components/MemoryCard.tsx` | Create | 单张图片卡片：懒加载、错误占位、点击跳转、hover 效果 |
+| `src/components/__tests__/MemoryCard.test.tsx` | Create | MemoryCard 渲染、点击跳转、错误状态测试 |
+| `src/components/MasonryGrid.tsx` | Create | 瀑布流布局：ResizeObserver 响应式列数、轮询分配、StaggerContainer 动画 |
+| `src/components/__tests__/MasonryGrid.test.tsx` | Create | MasonryGrid 列数、分配逻辑、空状态测试 |
+| `src/components/EmptyMemories.tsx` | Create | 空状态组件（复用 EmptyState） |
+| `src/components/__tests__/EmptyMemories.test.tsx` | Create | EmptyMemories 渲染、文案、跳转测试 |
+| `src/app/memories/page.tsx` | Create | 照片墙页面 Server Component |
+| `src/components/CoverActions.tsx` | Modify | 添加"回忆照片墙"入口链接 |
+| `src/app/diary/page.tsx` | Modify | 标题旁添加"照片墙"入口链接 |
+
+---
+
+### Task 1: Server Action `getAllDiaryImages`
+
+**Files:**
+- Modify: `src/lib/actions.ts`
+- Modify: `src/lib/__tests__/actions.test.ts`
+
+- [ ] **Step 1: 写 failing test**
+
+在 `src/lib/__tests__/actions.test.ts` 的 import 语句中追加 `getAllDiaryImages`：
+
+```typescript
+import {
+  createDiary,
+  getDiaryById,
+  getDiaryList,
+  updateDiary,
+  deleteDiary,
+  getDiaryNeighbors,
+  getCoupleProfile,
+  updateCoupleProfile,
+  getCoverStats,
+  saveCoupleProfileAction,
+  getAllDiaryImages,
+} from '../actions';
+```
+
+在文件末尾追加测试：
+
+```typescript
+describe('getAllDiaryImages', () => {
+  test('返回所有图片并按日记日期倒序排列', async () => {
+    const entry1 = await createDiary({
+      date: new Date('2025-01-15'),
+      title: '第一次约会',
+      content: '内容1',
+      mood: 'happy',
+      images: ['https://example.com/photo1.jpg'],
+    });
+
+    const entry2 = await createDiary({
+      date: new Date('2025-02-20'),
+      title: '情人节',
+      content: '内容2',
+      mood: 'sweet',
+      images: ['https://example.com/photo2.jpg', 'https://example.com/photo3.jpg'],
+    });
+
+    const images = await getAllDiaryImages();
+
+    expect(images).toHaveLength(3);
+    // 按日期倒序：entry2 的图片在前
+    expect(images[0].entryId).toBe(entry2.id);
+    expect(images[1].entryId).toBe(entry2.id);
+    expect(images[2].entryId).toBe(entry1.id);
+    expect(images[0].url).toBe('https://example.com/photo2.jpg');
+  });
+
+  test('空数据时返回空数组', async () => {
+    const images = await getAllDiaryImages();
+    expect(images).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `pnpm test -- src/lib/__tests__/actions.test.ts -t "getAllDiaryImages"`
+Expected: FAIL with "getAllDiaryImages is not defined" 或类似错误
+
+- [ ] **Step 3: 实现 `getAllDiaryImages`**
+
+在 `src/lib/actions.ts` 的 `getCoverStats` 函数之后追加：
+
+```typescript
+export async function getAllDiaryImages() {
+  return prisma.diaryImage.findMany({
+    orderBy: {
+      entry: { date: 'desc' },
+    },
+    include: { entry: { select: { id: true, date: true } } },
+  });
+}
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `pnpm test -- src/lib/__tests__/actions.test.ts -t "getAllDiaryImages"`
+Expected: PASS (2 tests passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/actions.ts src/lib/__tests__/actions.test.ts
+git commit -m "feat(actions): 添加 getAllDiaryImages Server Action"
+```
+
+---
+
+### Task 2: MemoryCard 组件
+
+**Files:**
+- Create: `src/components/MemoryCard.tsx`
+- Create: `src/components/__tests__/MemoryCard.test.tsx`
+
+- [ ] **Step 1: 写 failing test**
+
+创建 `src/components/__tests__/MemoryCard.test.tsx`：
+
+```typescript
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryCard } from '../MemoryCard';
+
+jest.mock('next/link', () => {
+  return function MockLink({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) {
+    return <a href={href}>{children}</a>;
+  };
+});
+
+jest.mock('../animations', () => ({
+  StaggerItem: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+describe('MemoryCard', () => {
+  const mockImage = {
+    id: 'img1',
+    url: 'https://example.com/photo.jpg',
+    entryId: 'entry1',
+  };
+
+  test('渲染图片和链接', () => {
+    render(<MemoryCard image={mockImage} />);
+    const img = screen.getByAltText('回忆照片');
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute('src', 'https://example.com/photo.jpg');
+    expect(img).toHaveAttribute('loading', 'lazy');
+    expect(img.closest('a')).toHaveAttribute('href', '/diary/entry1');
+  });
+
+  test('图片加载失败时显示占位符', () => {
+    render(<MemoryCard image={mockImage} />);
+    const img = screen.getByAltText('回忆照片');
+    fireEvent.error(img);
+    expect(screen.getByText('图片加载失败')).toBeInTheDocument();
+    expect(img).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `pnpm test -- src/components/__tests__/MemoryCard.test.tsx`
+Expected: FAIL with "Cannot find module '../MemoryCard'"
+
+- [ ] **Step 3: 实现 MemoryCard**
+
+创建 `src/components/MemoryCard.tsx`：
+
+```tsx
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+import { StaggerItem } from './animations';
+
+interface MemoryCardProps {
+  image: {
+    id: string;
+    url: string;
+    entryId: string;
+  };
+}
+
+export function MemoryCard({ image }: MemoryCardProps) {
+  const [hasError, setHasError] = useState(false);
+
+  return (
+    <StaggerItem>
+      <Link href={`/diary/${image.entryId}`} className="block">
+        {hasError ? (
+          <div className="w-full aspect-4/3 bg-border-soft rounded-xl flex items-center justify-center">
+            <span className="text-xs text-text-sub">图片加载失败</span>
+          </div>
+        ) : (
+          <img
+            src={image.url}
+            alt="回忆照片"
+            loading="lazy"
+            className="w-full h-auto rounded-xl object-cover hover:scale-[1.02] hover:shadow-md transition-all duration-200"
+            onError={() => setHasError(true)}
+          />
+        )}
+      </Link>
+    </StaggerItem>
+  );
+}
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `pnpm test -- src/components/__tests__/MemoryCard.test.tsx`
+Expected: PASS (2 tests passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/MemoryCard.tsx src/components/__tests__/MemoryCard.test.tsx
+git commit -m "feat(memories): 添加 MemoryCard 组件"
+```
+
+---
+
+### Task 3: MasonryGrid 组件
+
+**Files:**
+- Create: `src/components/MasonryGrid.tsx`
+- Create: `src/components/__tests__/MasonryGrid.test.tsx`
+
+- [ ] **Step 1: 写 failing test**
+
+创建 `src/components/__tests__/MasonryGrid.test.tsx`：
+
+```typescript
+import { render, screen, act } from '@testing-library/react';
+import { MasonryGrid } from '../MasonryGrid';
+
+jest.mock('next/link', () => {
+  return function MockLink({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) {
+    return <a href={href}>{children}</a>;
+  };
+});
+
+jest.mock('../animations', () => ({
+  StaggerContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="stagger-container">{children}</div>
+  ),
+  StaggerItem: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+let resizeCallback: ((entries: Array<{ contentRect: { width: number } }>) => void) | null = null;
+
+class MockResizeObserver {
+  constructor(callback: typeof resizeCallback) {
+    resizeCallback = callback;
+  }
+  observe = jest.fn();
+  disconnect = jest.fn();
+}
+
+global.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+
+describe('MasonryGrid', () => {
+  const mockImages = [
+    { id: '1', url: 'https://example.com/1.jpg', entryId: 'e1' },
+    { id: '2', url: 'https://example.com/2.jpg', entryId: 'e2' },
+    { id: '3', url: 'https://example.com/3.jpg', entryId: 'e3' },
+    { id: '4', url: 'https://example.com/4.jpg', entryId: 'e4' },
+  ];
+
+  test('渲染所有图片卡片', () => {
+    render(<MasonryGrid images={mockImages} />);
+    expect(screen.getAllByAltText('回忆照片')).toHaveLength(4);
+  });
+
+  test('空数组时不渲染图片', () => {
+    render(<MasonryGrid images={[]} />);
+    expect(screen.queryAllByAltText('回忆照片')).toHaveLength(0);
+  });
+
+  test('触发 ResizeObserver 回调后列数变化', () => {
+    render(<MasonryGrid images={mockImages} />);
+    // 初始宽度默认为 0，列数为 2
+    const containers = screen.getAllByTestId('stagger-container');
+    expect(containers).toHaveLength(2);
+
+    // 模拟宽度 >= 640px，应变为 3 列
+    act(() => {
+      resizeCallback?.([{ contentRect: { width: 700 } }]);
+    });
+
+    const containersAfter = screen.getAllByTestId('stagger-container');
+    expect(containersAfter).toHaveLength(3);
+  });
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `pnpm test -- src/components/__tests__/MasonryGrid.test.tsx`
+Expected: FAIL with "Cannot find module '../MasonryGrid'"
+
+- [ ] **Step 3: 实现 MasonryGrid**
+
+创建 `src/components/MasonryGrid.tsx`：
+
+```tsx
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import { MemoryCard } from './MemoryCard';
+import { StaggerContainer } from './animations';
+
+interface ImageItem {
+  id: string;
+  url: string;
+  entryId: string;
+}
+
+interface MasonryGridProps {
+  images: ImageItem[];
+}
+
+function getColumnCount(width: number): number {
+  return width >= 640 ? 3 : 2;
+}
+
+export function MasonryGrid({ images }: MasonryGridProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [columnCount, setColumnCount] = useState(2);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        setColumnCount(getColumnCount(entry.contentRect.width));
+      }
+    });
+
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, []);
+
+  const columns: ImageItem[][] = Array.from(
+    { length: columnCount },
+    () => [],
+  );
+  images.forEach((image, index) => {
+    columns[index % columnCount].push(image);
+  });
+
+  return (
+    <div ref={containerRef} className="flex gap-2">
+      {columns.map((col, colIndex) => (
+        <div key={colIndex} className="flex-1 flex flex-col gap-2">
+          <StaggerContainer>
+            {col.map((image) => (
+              <MemoryCard key={image.id} image={image} />
+            ))}
+          </StaggerContainer>
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `pnpm test -- src/components/__tests__/MasonryGrid.test.tsx`
+Expected: PASS (3 tests passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/MasonryGrid.tsx src/components/__tests__/MasonryGrid.test.tsx
+git commit -m "feat(memories): 添加 MasonryGrid 瀑布流组件"
+```
+
+---
+
+### Task 4: EmptyMemories 组件
+
+**Files:**
+- Create: `src/components/EmptyMemories.tsx`
+- Create: `src/components/__tests__/EmptyMemories.test.tsx`
+
+- [ ] **Step 1: 写 failing test**
+
+创建 `src/components/__tests__/EmptyMemories.test.tsx`：
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import { EmptyMemories } from '../EmptyMemories';
+
+jest.mock('next/link', () => {
+  return function MockLink({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) {
+    return <a href={href}>{children}</a>;
+  };
+});
+
+jest.mock('animal-island-ui', () => ({
+  Button: ({ children, type }: { children: React.ReactNode; type?: string }) => (
+    <button data-type={type}>{children}</button>
+  ),
+}));
+
+jest.mock('../illustrations', () => ({
+  EmptyState: ({
+    message,
+    children,
+  }: {
+    message?: string;
+    children?: React.ReactNode;
+  }) => (
+    <div>
+      <p>{message}</p>
+      {children}
+    </div>
+  ),
+}));
+
+describe('EmptyMemories', () => {
+  test('渲染空状态文案和按钮', () => {
+    render(<EmptyMemories />);
+    expect(
+      screen.getByText('还没有照片呢，先写一篇日记配上图片吧'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '去写日记' })).toHaveAttribute(
+      'href',
+      '/diary/new',
+    );
+  });
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `pnpm test -- src/components/__tests__/EmptyMemories.test.tsx`
+Expected: FAIL with "Cannot find module '../EmptyMemories'"
+
+- [ ] **Step 3: 实现 EmptyMemories**
+
+创建 `src/components/EmptyMemories.tsx`：
+
+```tsx
+import Link from 'next/link';
+import { Button } from 'animal-island-ui';
+import { EmptyState } from './illustrations';
+
+export function EmptyMemories() {
+  return (
+    <EmptyState message="还没有照片呢，先写一篇日记配上图片吧">
+      <div className="mt-4">
+        <Link href="/diary/new">
+          <Button type="primary">去写日记</Button>
+        </Link>
+      </div>
+    </EmptyState>
+  );
+}
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `pnpm test -- src/components/__tests__/EmptyMemories.test.tsx`
+Expected: PASS (1 test passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/EmptyMemories.tsx src/components/__tests__/EmptyMemories.test.tsx
+git commit -m "feat(memories): 添加 EmptyMemories 空状态组件"
+```
+
+---
+
+### Task 5: 照片墙页面
+
+**Files:**
+- Create: `src/app/memories/page.tsx`
+
+- [ ] **Step 1: 实现页面**
+
+创建 `src/app/memories/page.tsx`：
+
+```tsx
+import type { Metadata } from 'next';
+import { getAllDiaryImages } from '@/lib/actions';
+import { MasonryGrid } from '@/components/MasonryGrid';
+import { EmptyMemories } from '@/components/EmptyMemories';
+
+export const metadata: Metadata = {
+  title: '回忆照片墙',
+};
+
+export default async function MemoriesPage() {
+  const images = await getAllDiaryImages();
+
+  return (
+    <main className="min-h-screen bg-cream">
+      <div className="max-w-[480px] mx-auto px-4 py-6">
+        <h1 className="text-xl font-bold text-text-main mb-4">回忆照片墙</h1>
+        {images.length === 0 ? (
+          <EmptyMemories />
+        ) : (
+          <MasonryGrid
+            images={images.map((img) => ({
+              id: img.id,
+              url: img.url,
+              entryId: img.entryId,
+            }))}
+          />
+        )}
+      </div>
+    </main>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/app/memories/page.tsx
+git commit -m "feat(memories): 添加照片墙页面"
+```
+
+---
+
+### Task 6: 封面页入口
+
+**Files:**
+- Modify: `src/components/CoverActions.tsx`
+
+- [ ] **Step 1: 修改 CoverActions**
+
+在 `src/components/CoverActions.tsx` 的 import 区域添加 `Link`：
+
+```typescript
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import FloatingButton from './FloatingButton';
+```
+
+在按钮组中，"翻开日记"按钮和 FloatingButton 之间插入：
+
+```tsx
+<Link
+  href="/memories"
+  className="text-sm text-text-sub hover:text-text-main transition-colors"
+>
+  回忆照片墙
+</Link>
+```
+
+最终按钮组结构：
+
+```tsx
+<div className='absolute bottom-32 left-1/2 -translate-x-1/2 flex flex-col items-center gap-3'>
+  <button onClick={handleReadClick} className='...'>翻开日记</button>
+  <Link href="/memories" className="text-sm text-text-sub hover:text-text-main transition-colors">
+    回忆照片墙
+  </Link>
+  {showWriteButton && (
+    <FloatingButton href='/diary/new'>写下今天</FloatingButton>
+  )}
+</div>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/CoverActions.tsx
+git commit -m "feat(cover): 添加回忆照片墙入口"
+```
+
+---
+
+### Task 7: 日记时间线入口
+
+**Files:**
+- Modify: `src/app/diary/page.tsx`
+
+- [ ] **Step 1: 修改 diary/page.tsx**
+
+在 `src/app/diary/page.tsx` 的 import 区域添加 `Link`：
+
+```typescript
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { getDiaryList } from '@/lib/actions';
+```
+
+修改标题区域：
+
+```tsx
+<div className="max-w-[480px] mx-auto px-4 py-6">
+  <div className="flex items-center justify-between mb-6">
+    <div className="flex items-center gap-4">
+      <BackButton />
+      <h1 className="text-lg font-bold text-text-main">目录</h1>
+    </div>
+    <Link
+      href="/memories"
+      className="text-sm text-primary hover:text-accent transition-colors"
+    >
+      照片墙
+    </Link>
+  </div>
+  <DiaryTimeline groups={groups} showWriteButton={role === 'admin'} />
+</div>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/app/diary/page.tsx
+git commit -m "feat(diary): 添加照片墙入口链接"
+```
+
+---
+
+### Task 8: 验证
+
+- [ ] **Step 1: 运行全部测试**
+
+Run: `pnpm test`
+Expected: All tests pass（包括新增的和已有的）
+
+- [ ] **Step 2: 运行 ESLint**
+
+Run: `pnpm lint`
+Expected: No errors
+
+- [ ] **Step 3: 运行生产构建**
+
+Run: `pnpm build`
+Expected: Build succeeds
+
+- [ ] **Step 4: 提交验证结果**
+
+如果以上全部通过：
+
+```bash
+git log --oneline -8
+```
+
+将 8 条提交记录作为验证证据。
+
+---
+
+## Spec Coverage Check
+
+| Spec 要求 | 对应 Task |
+|-----------|-----------|
+| 瀑布流布局展示外链图片 | Task 3 (MasonryGrid) |
+| 移动端 2 列、桌面端 3 列 | Task 3 (getColumnCount) |
+| 图片圆角 12px、gap 8px | Task 2 (MemoryCard rounded-xl), Task 3 (gap-2) |
+| 点击图片跳转对应日记 | Task 2 (MemoryCard Link href) |
+| 按时间倒序排列 | Task 1 (orderBy entry.date desc) |
+| 空状态处理 | Task 4 (EmptyMemories) |
+| 图片加载失败占位符 | Task 2 (hasError fallback) |
+| 封面页 + 时间线页双入口 | Task 6, Task 7 |
+| 入场动画 | Task 2, 3 (StaggerItem/StaggerContainer) |
+| 懒加载 | Task 2 (img loading="lazy") |
+
+## Placeholder Scan
+
+- 无 TBD / TODO / "implement later" / "fill in details"
+- 所有步骤包含完整代码
+- 所有测试包含实际断言代码
+- 无 "Similar to Task N" 引用
+
+## Type Consistency Check
+
+- `getAllDiaryImages` 返回 `(DiaryImage & { entry: ... })[]`，page.tsx 中 map 为 `{ id, url, entryId }`
+- `MemoryCardProps.image` 类型 `{ id, url, entryId }` 与 page.tsx 传递的结构一致
+- `MasonryGridProps.images` 类型 `ImageItem[]` 与 `MemoryCardProps` 一致

--- a/docs/superpowers/specs/2026-05-07-memories-wall-design.md
+++ b/docs/superpowers/specs/2026-05-07-memories-wall-design.md
@@ -1,0 +1,219 @@
+# Issue #12 回忆照片墙设计文档
+
+## PRD 引用
+
+- 来源文档：docs/superpowers/specs/2026-04-30-love-diary-design.md
+- 关联 Issue：#12
+
+## 背景与目标
+
+### 背景
+
+回忆照片墙是 P1 阶段功能，用于展示日记中的外链图片，形成照片墙效果。这是给用户和伴侣回顾照片的重要入口。
+
+### 目标
+
+实现一个简洁的照片墙页面，展示所有日记中的外链图片，采用瀑布流布局，支持入场动画和懒加载。
+
+## 范围界定
+
+### 包含范围
+
+- 瀑布流布局展示所有外链图片
+- 点击图片查看关联日记
+- 按时间倒序排列
+- 空状态处理
+- 图片加载失败占位符
+- 封面页 + 日记时间线页 双入口
+- 图片入场动画（StaggerContainer）
+- 图片懒加载
+
+### 不包含范围
+
+- 图片本地上传（P1 仍使用外链 URL）
+- 按月份筛选（P2）
+- 图片预览弹窗（P2）
+- 复杂 3D 动画或粒子效果
+
+## 架构设计
+
+### 目录结构
+
+```
+src/
+  app/
+    memories/
+      page.tsx                 # Server Component：获取数据、渲染页面
+  components/
+    MasonryGrid.tsx            # Client Component：瀑布流布局计算
+    MemoryCard.tsx             # 单张图片卡片（点击跳转）
+    EmptyMemories.tsx          # 空状态（复用 EmptyState）
+  lib/
+    actions.ts                 # 新增 getAllDiaryImages()
+```
+
+### 现有文件修改
+
+- `src/components/CoverActions.tsx` — 添加"回忆照片墙"入口
+- `src/app/diary/page.tsx`（或 DiaryTimeline 附近）— 添加照片墙入口
+
+### 组件职责
+
+| 组件 | 类型 | 职责 |
+|------|------|------|
+| `page.tsx` | Server Component | 调用 `getAllDiaryImages()`，将图片数组传给 `MasonryGrid` |
+| `MasonryGrid` | Client Component | 接收图片数组，用 `useEffect` 计算列高，将图片分配到最短列，渲染多列结构 |
+| `MemoryCard` | Client Component | 显示单张图片（`img` 标签 + `loading="lazy"`），包裹在 `StaggerItem` 中，点击跳转 `/diary/[entryId]` |
+| `EmptyMemories` | Client Component | 无图片时显示空状态插画 + 文案 |
+
+## 数据流设计
+
+### 新增 Server Action
+
+```typescript
+export async function getAllDiaryImages() {
+  return prisma.diaryImage.findMany({
+    orderBy: {
+      entry: { date: 'desc' },
+    },
+    include: { entry: { select: { id: true, date: true } } },
+  });
+}
+```
+
+返回类型：`(DiaryImage & { entry: { id: string; date: Date } })[]`，按关联日记的 `date` 倒序排列。
+
+### page.tsx 数据流
+
+```tsx
+export default async function MemoriesPage() {
+  const images = await getAllDiaryImages();
+  return (
+    <main className="max-w-[480px] mx-auto px-4 py-6">
+      <h1 className="text-xl font-bold text-text-main mb-4">回忆照片墙</h1>
+      {images.length === 0 ? (
+        <EmptyMemories />
+      ) : (
+        <MasonryGrid images={images} />
+      )}
+    </main>
+  );
+}
+```
+
+全链路 Server Component，首屏直接渲染 HTML，无额外数据请求。
+
+## UI 设计
+
+### 瀑布流算法
+
+用 ResizeObserver 监听容器宽度，计算当前应有几列：
+- 容器宽度 < 640px：2 列
+- 容器宽度 >= 640px：3 列
+
+每张图片加载后获取其渲染高度，分配到当前**高度最短**的列中。这样形成自然的错落效果。
+
+### 样式约定
+
+- 图片圆角：`rounded-xl`（12px）
+- 列间距：`gap-2`（8px）
+- 图片填充：`w-full h-auto object-cover`
+- 页面标题：`text-xl font-bold text-text-main`
+- 页面边距：`px-4 py-6`
+- 整体最大宽度：`max-w-[480px] mx-auto`
+
+### 图片加载失败占位符
+
+图片 `onError` 时切换为占位状态——显示一个与主题色一致的圆角色块，中心一个小图标提示加载失败：
+
+```tsx
+<div className="w-full aspect-[4/3] bg-border-soft rounded-xl flex items-center justify-center">
+  <span className="text-xs text-text-sub">图片加载失败</span>
+</div>
+```
+
+## 动画与交互
+
+### 入场动画
+
+`MasonryGrid` 内部用 `StaggerContainer` 包裹所有图片卡片，`MemoryCard` 用 `StaggerItem` 包裹。
+
+效果：图片依次淡入 + 轻微上浮（opacity 0→1, y: 8→0），每张间隔 60ms，时长 250ms，使用已有动画系统的 `gentleEase` 缓动。
+
+### 减少动画偏好
+
+复用 `useReducedMotion` hook，系统开启减少动画时直接显示，无过渡。
+
+### 交互
+
+- 点击图片 → 跳转 `/diary/[entryId]`（Next.js `Link` 包裹）
+- hover 状态：图片轻微放大 `scale(1.02)` + 阴影加深，过渡 200ms
+- 不使用 `whileTap`，因为图片是链接而非按钮
+
+### 懒加载
+
+所有 `img` 标签设置 `loading="lazy"`，滚动到视口附近再加载。
+
+## 错误处理与空状态
+
+### 空状态
+
+无图片时显示 `EmptyMemories`：
+
+```tsx
+<EmptyState message="还没有照片呢，先写一篇日记配上图片吧">
+  <Link href="/diary/new">
+    <Button type="primary">去写日记</Button>
+  </Link>
+</EmptyState>
+```
+
+复用现有的 `EmptyState` 组件，自定义文案和跳转按钮。
+
+### 图片加载失败
+
+单张图片 `onError` 后显示占位，保持卡片占位，不破坏瀑布流布局。
+
+### 服务端错误
+
+`getAllDiaryImages()` 异常时，`page.tsx` 使用 Next.js `error.tsx` 降级处理（项目已有全局 error.tsx）。
+
+## 页面入口设计
+
+### 封面页入口（CoverActions.tsx）
+
+在"翻开日记"按钮旁添加二级入口，用纯文字链接，不抢主按钮的视觉焦点：
+
+```tsx
+<div className="absolute bottom-32 left-1/2 -translate-x-1/2 flex flex-col items-center gap-3">
+  <button onClick={handleReadClick} className="...">翻开日记</button>
+  <button onClick={handleMemoriesClick} className="text-sm text-text-sub hover:text-text-main transition-colors">
+    回忆照片墙
+  </button>
+  {showWriteButton && <FloatingButton href='/diary/new'>写下今天</FloatingButton>}
+</div>
+```
+
+### 日记时间线入口
+
+在 `DiaryTimeline` 顶部、月份分组之前，添加一个 subtle 入口：
+
+```tsx
+<div className="flex justify-between items-center mb-4">
+  <h1 className="text-xl font-bold">恋爱日记</h1>
+  <Link href="/memories" className="text-sm text-primary hover:text-accent">
+    照片墙
+  </Link>
+</div>
+```
+
+## 依赖关系
+
+- 依赖：Issue #2（DiaryImage 数据模型，已就绪）
+- 阻塞：无
+
+## 风险与注意事项
+
+- 外链图片可能存在跨域问题，已考虑错误处理（占位符）
+- 图片数量多时使用原生 `loading="lazy"` 懒加载
+- 瀑布流布局依赖客户端 JS 计算，首屏可能有轻微布局偏移（使用 `useEffect` + ResizeObserver 最小化）

--- a/src/app/diary/page.tsx
+++ b/src/app/diary/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
 import { getDiaryList } from '@/lib/actions';
 import { getAuthRole } from '@/lib/auth';
 import { DiaryTimeline } from '@/components/DiaryTimeline';
@@ -36,9 +37,17 @@ export default async function DiaryPage() {
   return (
     <main className="min-h-screen bg-cream">
       <div className="max-w-[480px] mx-auto px-4 py-6">
-        <div className="flex items-center gap-4 mb-6">
-          <BackButton />
-          <h1 className="text-lg font-bold text-text-main">目录</h1>
+        <div className="flex items-center justify-between mb-6">
+          <div className="flex items-center gap-4">
+            <BackButton />
+            <h1 className="text-lg font-bold text-text-main">目录</h1>
+          </div>
+          <Link
+            href="/memories"
+            className="text-sm text-primary hover:text-accent transition-colors"
+          >
+            照片墙
+          </Link>
         </div>
         <DiaryTimeline groups={groups} showWriteButton={role === 'admin'} />
       </div>

--- a/src/app/memories/page.tsx
+++ b/src/app/memories/page.tsx
@@ -1,0 +1,31 @@
+import type { Metadata } from 'next';
+import { getAllDiaryImages } from '@/lib/actions';
+import { MasonryGrid } from '@/components/MasonryGrid';
+import { EmptyMemories } from '@/components/EmptyMemories';
+
+export const metadata: Metadata = {
+  title: '回忆照片墙',
+};
+
+export default async function MemoriesPage() {
+  const images = await getAllDiaryImages();
+
+  return (
+    <main className="min-h-screen bg-cream">
+      <div className="max-w-[480px] mx-auto px-4 py-6">
+        <h1 className="text-xl font-bold text-text-main mb-4">回忆照片墙</h1>
+        {images.length === 0 ? (
+          <EmptyMemories />
+        ) : (
+          <MasonryGrid
+            images={images.map((img) => ({
+              id: img.id,
+              url: img.url,
+              entryId: img.entryId,
+            }))}
+          />
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/app/memories/page.tsx
+++ b/src/app/memories/page.tsx
@@ -22,6 +22,7 @@ export default async function MemoriesPage() {
               id: img.id,
               url: img.url,
               entryId: img.entryId,
+              title: img.entry.title,
             }))}
           />
         )}

--- a/src/components/CoverActions.tsx
+++ b/src/components/CoverActions.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 import FloatingButton from './FloatingButton';
 import ViewPasswordModal from './ViewPasswordModal';
 
@@ -32,6 +33,12 @@ export default function CoverActions({ isAuthenticated, href, showWriteButton }:
         >
           翻开日记
         </button>
+        <Link
+          href="/memories"
+          className="text-sm text-text-sub hover:text-text-main transition-colors"
+        >
+          回忆照片墙
+        </Link>
         {showWriteButton && (
           <FloatingButton href='/diary/new'>写下今天</FloatingButton>
         )}

--- a/src/components/EmptyMemories.tsx
+++ b/src/components/EmptyMemories.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link'
+import { Button } from 'animal-island-ui'
+import { EmptyState } from './illustrations'
+
+export function EmptyMemories() {
+  return (
+    <EmptyState message="还没有照片呢，先写一篇日记配上图片吧">
+      <div className="mt-4">
+        <Link href="/diary/new">
+          <Button type="primary">去写日记</Button>
+        </Link>
+      </div>
+    </EmptyState>
+  )
+}

--- a/src/components/MasonryGrid.tsx
+++ b/src/components/MasonryGrid.tsx
@@ -8,6 +8,7 @@ interface ImageItem {
   id: string;
   url: string;
   entryId: string;
+  title: string | null;
 }
 
 interface MasonryGridProps {

--- a/src/components/MasonryGrid.tsx
+++ b/src/components/MasonryGrid.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import { MemoryCard } from './MemoryCard';
+import { StaggerContainer } from './animations';
+
+interface ImageItem {
+  id: string;
+  url: string;
+  entryId: string;
+}
+
+interface MasonryGridProps {
+  images: ImageItem[];
+}
+
+function getColumnCount(width: number): number {
+  return width >= 640 ? 3 : 2;
+}
+
+export function MasonryGrid({ images }: MasonryGridProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [columnCount, setColumnCount] = useState(2);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        setColumnCount(getColumnCount(entry.contentRect.width));
+      }
+    });
+
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, []);
+
+  const columns: ImageItem[][] = Array.from(
+    { length: columnCount },
+    () => [],
+  );
+  images.forEach((image, index) => {
+    columns[index % columnCount].push(image);
+  });
+
+  return (
+    <div ref={containerRef} className="flex gap-2">
+      {columns.map((col, colIndex) => (
+        <div key={colIndex} className="flex-1 flex flex-col gap-2">
+          <StaggerContainer>
+            {col.map((image) => (
+              <MemoryCard key={image.id} image={image} />
+            ))}
+          </StaggerContainer>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/MemoryCard.tsx
+++ b/src/components/MemoryCard.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+import { StaggerItem } from './animations';
+
+interface MemoryCardProps {
+  image: {
+    id: string;
+    url: string;
+    entryId: string;
+  };
+}
+
+export function MemoryCard({ image }: MemoryCardProps) {
+  const [hasError, setHasError] = useState(false);
+
+  return (
+    <StaggerItem>
+      <Link href={`/diary/${image.entryId}`} className="block">
+        {hasError ? (
+          <div className="w-full aspect-4/3 bg-border-soft rounded-xl flex items-center justify-center">
+            <span className="text-xs text-text-sub">图片加载失败</span>
+          </div>
+        ) : (
+          <img
+            src={image.url}
+            alt="回忆照片"
+            loading="lazy"
+            className="w-full h-auto rounded-xl object-cover hover:scale-[1.02] hover:shadow-md transition-all duration-200"
+            onError={() => setHasError(true)}
+          />
+        )}
+      </Link>
+    </StaggerItem>
+  );
+}

--- a/src/components/MemoryCard.tsx
+++ b/src/components/MemoryCard.tsx
@@ -9,6 +9,7 @@ interface MemoryCardProps {
     id: string;
     url: string;
     entryId: string;
+    title: string | null;
   };
 }
 
@@ -19,13 +20,13 @@ export function MemoryCard({ image }: MemoryCardProps) {
     <StaggerItem>
       <Link href={`/diary/${image.entryId}`} className="block">
         {hasError ? (
-          <div className="w-full aspect-4/3 bg-border-soft rounded-xl flex items-center justify-center">
+          <div className="w-full min-h-[120px] bg-border-soft rounded-xl flex items-center justify-center">
             <span className="text-xs text-text-sub">图片加载失败</span>
           </div>
         ) : (
           <img
             src={image.url}
-            alt="回忆照片"
+            alt={image.title ?? '回忆照片'}
             loading="lazy"
             className="w-full h-auto rounded-xl object-cover hover:scale-[1.02] hover:shadow-md transition-all duration-200"
             onError={() => setHasError(true)}

--- a/src/components/__tests__/EmptyMemories.test.tsx
+++ b/src/components/__tests__/EmptyMemories.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import { EmptyMemories } from '../EmptyMemories';
+
+jest.mock('next/link', () => {
+  return function MockLink({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) {
+    return <a href={href}>{children}</a>;
+  };
+});
+
+jest.mock('animal-island-ui', () => ({
+  Button: ({ children, type }: { children: React.ReactNode; type?: string }) => (
+    <button data-type={type}>{children}</button>
+  ),
+}));
+
+jest.mock('../illustrations', () => ({
+  EmptyState: ({
+    message,
+    children,
+  }: {
+    message?: string;
+    children?: React.ReactNode;
+  }) => (
+    <div>
+      <p>{message}</p>
+      {children}
+    </div>
+  ),
+}));
+
+describe('EmptyMemories', () => {
+  test('渲染空状态文案和按钮', () => {
+    render(<EmptyMemories />);
+    expect(
+      screen.getByText('还没有照片呢，先写一篇日记配上图片吧'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '去写日记' })).toHaveAttribute(
+      'href',
+      '/diary/new',
+    );
+  });
+});

--- a/src/components/__tests__/MasonryGrid.test.tsx
+++ b/src/components/__tests__/MasonryGrid.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, act } from '@testing-library/react';
+import { MasonryGrid } from '../MasonryGrid';
+
+jest.mock('next/link', () => {
+  return function MockLink({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) {
+    return <a href={href}>{children}</a>;
+  };
+});
+
+jest.mock('../animations', () => ({
+  StaggerContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="stagger-container">{children}</div>
+  ),
+  StaggerItem: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+let resizeCallback: ((entries: Array<{ contentRect: { width: number } }>) => void) | null = null;
+
+class MockResizeObserver {
+  constructor(callback: typeof resizeCallback) {
+    resizeCallback = callback;
+  }
+  observe = jest.fn();
+  disconnect = jest.fn();
+}
+
+global.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+
+describe('MasonryGrid', () => {
+  const mockImages = [
+    { id: '1', url: 'https://example.com/1.jpg', entryId: 'e1' },
+    { id: '2', url: 'https://example.com/2.jpg', entryId: 'e2' },
+    { id: '3', url: 'https://example.com/3.jpg', entryId: 'e3' },
+    { id: '4', url: 'https://example.com/4.jpg', entryId: 'e4' },
+  ];
+
+  test('渲染所有图片卡片', () => {
+    render(<MasonryGrid images={mockImages} />);
+    expect(screen.getAllByAltText('回忆照片')).toHaveLength(4);
+  });
+
+  test('空数组时不渲染图片', () => {
+    render(<MasonryGrid images={[]} />);
+    expect(screen.queryAllByAltText('回忆照片')).toHaveLength(0);
+  });
+
+  test('触发 ResizeObserver 回调后列数变化', () => {
+    render(<MasonryGrid images={mockImages} />);
+    // 初始宽度默认为 0，列数为 2
+    const containers = screen.getAllByTestId('stagger-container');
+    expect(containers).toHaveLength(2);
+
+    // 模拟宽度 >= 640px，应变为 3 列
+    act(() => {
+      resizeCallback?.([{ contentRect: { width: 700 } }]);
+    });
+
+    const containersAfter = screen.getAllByTestId('stagger-container');
+    expect(containersAfter).toHaveLength(3);
+  });
+});

--- a/src/components/__tests__/MemoryCard.test.tsx
+++ b/src/components/__tests__/MemoryCard.test.tsx
@@ -24,11 +24,12 @@ describe('MemoryCard', () => {
     id: 'img1',
     url: 'https://example.com/photo.jpg',
     entryId: 'entry1',
+    title: '第一次约会',
   };
 
   test('渲染图片和链接', () => {
     render(<MemoryCard image={mockImage} />);
-    const img = screen.getByAltText('回忆照片');
+    const img = screen.getByAltText('第一次约会');
     expect(img).toBeInTheDocument();
     expect(img).toHaveAttribute('src', 'https://example.com/photo.jpg');
     expect(img).toHaveAttribute('loading', 'lazy');
@@ -37,7 +38,7 @@ describe('MemoryCard', () => {
 
   test('图片加载失败时显示占位符', () => {
     render(<MemoryCard image={mockImage} />);
-    const img = screen.getByAltText('回忆照片');
+    const img = screen.getByAltText('第一次约会');
     fireEvent.error(img);
     expect(screen.getByText('图片加载失败')).toBeInTheDocument();
     expect(img).not.toBeInTheDocument();

--- a/src/components/__tests__/MemoryCard.test.tsx
+++ b/src/components/__tests__/MemoryCard.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryCard } from '../MemoryCard';
+
+jest.mock('next/link', () => {
+  return function MockLink({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) {
+    return <a href={href}>{children}</a>;
+  };
+});
+
+jest.mock('../animations', () => ({
+  StaggerItem: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+describe('MemoryCard', () => {
+  const mockImage = {
+    id: 'img1',
+    url: 'https://example.com/photo.jpg',
+    entryId: 'entry1',
+  };
+
+  test('渲染图片和链接', () => {
+    render(<MemoryCard image={mockImage} />);
+    const img = screen.getByAltText('回忆照片');
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute('src', 'https://example.com/photo.jpg');
+    expect(img).toHaveAttribute('loading', 'lazy');
+    expect(img.closest('a')).toHaveAttribute('href', '/diary/entry1');
+  });
+
+  test('图片加载失败时显示占位符', () => {
+    render(<MemoryCard image={mockImage} />);
+    const img = screen.getByAltText('回忆照片');
+    fireEvent.error(img);
+    expect(screen.getByText('图片加载失败')).toBeInTheDocument();
+    expect(img).not.toBeInTheDocument();
+  });
+});

--- a/src/lib/__tests__/actions.test.ts
+++ b/src/lib/__tests__/actions.test.ts
@@ -10,6 +10,7 @@ import {
   updateCoupleProfile,
   getCoverStats,
   saveCoupleProfileAction,
+  getAllDiaryImages,
 } from '../actions';
 import dayjs from 'dayjs';
 
@@ -360,5 +361,39 @@ describe('saveCoupleProfileAction', () => {
 
     const profile = await prisma.coupleProfile.findFirst();
     expect(profile?.siteTitle).toBeNull();
+  });
+});
+
+describe('getAllDiaryImages', () => {
+  test('返回所有图片并按日记日期倒序排列', async () => {
+    const entry1 = await createDiary({
+      date: new Date('2025-01-15'),
+      title: '第一次约会',
+      content: '内容1',
+      mood: 'happy',
+      images: ['https://example.com/photo1.jpg'],
+    });
+
+    const entry2 = await createDiary({
+      date: new Date('2025-02-20'),
+      title: '情人节',
+      content: '内容2',
+      mood: 'sweet',
+      images: ['https://example.com/photo2.jpg', 'https://example.com/photo3.jpg'],
+    });
+
+    const images = await getAllDiaryImages();
+
+    expect(images).toHaveLength(3);
+    // 按日期倒序：entry2 的图片在前
+    expect(images[0].entryId).toBe(entry2.id);
+    expect(images[1].entryId).toBe(entry2.id);
+    expect(images[2].entryId).toBe(entry1.id);
+    expect(images[0].url).toBe('https://example.com/photo2.jpg');
+  });
+
+  test('空数据时返回空数组', async () => {
+    const images = await getAllDiaryImages();
+    expect(images).toEqual([]);
   });
 });

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -170,7 +170,7 @@ export async function getAllDiaryImages() {
     orderBy: {
       entry: { date: 'desc' },
     },
-    include: { entry: { select: { id: true, date: true } } },
+    include: { entry: { select: { id: true, date: true, title: true } } },
   });
 }
 

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -165,6 +165,15 @@ export async function getCoverStats() {
   return { diaryCount, memoryCount };
 }
 
+export async function getAllDiaryImages() {
+  return prisma.diaryImage.findMany({
+    orderBy: {
+      entry: { date: 'desc' },
+    },
+    include: { entry: { select: { id: true, date: true } } },
+  });
+}
+
 export type SettingsFormState = {
   ok: boolean;
   fieldErrors?: Partial<


### PR DESCRIPTION
## Summary

- 新增 `getAllDiaryImages` Server Action，按日记日期倒序查询所有外链图片
- 新增 `MemoryCard` 组件：懒加载、错误占位、点击跳转日记详情、hover 放大效果
- 新增 `MasonryGrid` 瀑布流组件：ResizeObserver 响应式列数（移动端 2 列 / 桌面端 3 列），集成 Stagger 入场动画
- 新增 `EmptyMemories` 空状态组件，引导用户去写日记
- 新增 `/memories` 照片墙页面
- 封面页和日记时间线页添加照片墙入口链接

## Test Plan

- [x] `getAllDiaryImages` 单元测试（多图片倒序 + 空数据）
- [x] `MemoryCard` 渲染和错误状态测试
- [x] `MasonryGrid` 列数和分配逻辑测试
- [x] `EmptyMemories` 空状态测试
- [x] `pnpm lint` 通过（0 errors）
- [x] `pnpm build` 成功

Fixes #12